### PR TITLE
Add AMMConfig module with create/view scripts

### DIFF
--- a/packages/dapp/src/scripts/owner/amm-create.ts
+++ b/packages/dapp/src/scripts/owner/amm-create.ts
@@ -1,0 +1,163 @@
+/**
+ * Creates a new shared AMM config for the target network.
+ */
+import yargs from "yargs"
+
+import {
+  DEFAULT_BASE_SPREAD_BPS,
+  DEFAULT_VOLATILITY_MULTIPLIER_BPS,
+  getAmmConfigOverview,
+  resolveAmmConfigInputs
+} from "@sui-amm/domain-core/models/amm"
+import { buildCreateAmmConfigTransaction } from "@sui-amm/domain-core/ptb/amm"
+import { resolveAmmPackageId } from "@sui-amm/domain-node/amm"
+import { emitJsonOutput } from "@sui-amm/tooling-node/json"
+import { runSuiScript } from "@sui-amm/tooling-node/process"
+import { findCreatedArtifactBySuffix } from "@sui-amm/tooling-node/transactions"
+import {
+  logAmmConfigOverview,
+  resolvePythPriceFeedIdHex
+} from "../../utils/amm.ts"
+
+type CreateAmmArguments = {
+  baseSpreadBps?: string
+  volatilityMultiplierBps?: string
+  useLaser?: boolean
+  pythPriceFeedId?: string
+  pythPriceFeedLabel?: string
+  ammPackageId?: string
+  devInspect?: boolean
+  dryRun?: boolean
+  json?: boolean
+}
+
+runSuiScript(
+  async (tooling, cliArguments: CreateAmmArguments) => {
+    const ammPackageId = await resolveAmmPackageId({
+      networkName: tooling.network.networkName,
+      ammPackageId: cliArguments.ammPackageId
+    })
+
+    const ammConfigInputs = await resolveAmmConfigInputs({
+      pythPriceFeedIdHex: await resolvePythPriceFeedIdHex({
+        networkName: tooling.network.networkName,
+        pythPriceFeedId: cliArguments.pythPriceFeedId,
+        pythPriceFeedLabel: cliArguments.pythPriceFeedLabel
+      }),
+      volatilityMultiplierBps: cliArguments.volatilityMultiplierBps,
+      baseSpreadBps: cliArguments.baseSpreadBps,
+      useLaser: cliArguments.useLaser
+    })
+
+    const createAmmTransaction = buildCreateAmmConfigTransaction({
+      packageId: ammPackageId,
+      baseSpreadBps: ammConfigInputs.baseSpreadBps,
+      volatilityMultiplierBps: ammConfigInputs.volatilityMultiplierBps,
+      useLaser: ammConfigInputs.useLaser,
+      pythPriceFeedIdBytes: ammConfigInputs.pythPriceFeedIdBytes
+    })
+
+    const { execution, summary } = await tooling.executeTransactionWithSummary({
+      transaction: createAmmTransaction,
+      signer: tooling.loadedEd25519KeyPair,
+      summaryLabel: "create-amm",
+      devInspect: cliArguments.devInspect,
+      dryRun: cliArguments.dryRun
+    })
+
+    if (!execution) return
+
+    const createdArtifacts = execution.objectArtifacts.created
+    const createdAmmConfig = findCreatedArtifactBySuffix(
+      createdArtifacts,
+      "::manager::AMMConfig"
+    )
+
+    if (!createdAmmConfig)
+      throw new Error(
+        "Expected an AMM config object to be created, but it was not found in transaction artifacts."
+      )
+
+    const ammConfigOverview = await getAmmConfigOverview(
+      createdAmmConfig.objectId,
+      tooling.suiClient
+    )
+
+    if (
+      emitJsonOutput(
+        {
+          ammConfig: ammConfigOverview,
+          digest: createdAmmConfig.digest,
+          initialSharedVersion: createdAmmConfig.initialSharedVersion,
+          pythPriceFeedIdHex: ammConfigInputs.pythPriceFeedIdHex,
+          transactionSummary: summary
+        },
+        cliArguments.json
+      )
+    )
+      return
+
+    logAmmConfigOverview(ammConfigOverview, {
+      initialSharedVersion: createdAmmConfig.initialSharedVersion
+    })
+  },
+  yargs()
+    .option("baseSpreadBps", {
+      alias: ["base-spread-bps"],
+      type: "string",
+      description: "Base spread in basis points (u64).",
+      default: DEFAULT_BASE_SPREAD_BPS,
+      demandOption: false
+    })
+    .option("volatilityMultiplierBps", {
+      alias: ["volatility-multiplier-bps"],
+      type: "string",
+      description: "Volatility multiplier in basis points (u64).",
+      default: DEFAULT_VOLATILITY_MULTIPLIER_BPS,
+      demandOption: false
+    })
+    .option("useLaser", {
+      alias: ["use-laser"],
+      type: "boolean",
+      default: false,
+      description: "Enable the laser pricing path for the AMM."
+    })
+    .option("pythPriceFeedId", {
+      alias: ["pyth-price-feed-id", "pyth-feed-id"],
+      type: "string",
+      description: "Pyth price feed id (32 bytes hex).",
+      demandOption: false
+    })
+    .option("pythPriceFeedLabel", {
+      alias: ["pyth-price-feed-label", "pyth-feed-label"],
+      type: "string",
+      description:
+        "Localnet mock feed label to resolve the feed id when --pyth-price-feed-id is omitted.",
+      demandOption: false
+    })
+    .option("ammPackageId", {
+      alias: ["amm-package-id"],
+      type: "string",
+      description:
+        "Package ID for the amm Move package; inferred from the latest publish entry in deployments/deployment.<network>.json when omitted.",
+      demandOption: false
+    })
+    .option("devInspect", {
+      alias: ["dev-inspect", "debug"],
+      type: "boolean",
+      default: false,
+      description: "Run a dev-inspect and log VM error details."
+    })
+    .option("dryRun", {
+      alias: ["dry-run"],
+      type: "boolean",
+      default: false,
+      description: "Run dev-inspect and exit without executing the transaction."
+    })
+    .option("json", {
+      type: "boolean",
+      default: false,
+      description: "Output results as JSON."
+    })
+    .strict()
+)

--- a/packages/dapp/src/scripts/owner/test-integration/amm-create.test.ts
+++ b/packages/dapp/src/scripts/owner/test-integration/amm-create.test.ts
@@ -1,0 +1,157 @@
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+import {
+  AMM_CONFIG_TYPE_SUFFIX,
+  type AmmConfigOverview
+} from "@sui-amm/domain-core/models/amm"
+import { DEFAULT_MOCK_PRICE_FEED } from "@sui-amm/domain-core/models/pyth"
+import { normalizeHex } from "@sui-amm/tooling-core/hex"
+import { extractInitialSharedVersion } from "@sui-amm/tooling-core/shared-object"
+import { pickRootNonDependencyArtifact } from "@sui-amm/tooling-node/artifacts"
+import { createSuiLocalnetTestEnv } from "@sui-amm/tooling-node/testing/env"
+import {
+  resolveDappMoveRoot,
+  resolveDappRoot
+} from "@sui-amm/tooling-node/testing/paths"
+import {
+  createSuiScriptRunner,
+  parseJsonFromScriptOutput
+} from "@sui-amm/tooling-node/testing/scripts"
+
+type AmmCreateOutput = {
+  ammConfig?: AmmConfigOverview
+  digest?: string
+  initialSharedVersion?: string
+  pythPriceFeedIdHex?: string
+  transactionSummary?: { label?: string }
+}
+
+type ObjectArtifact = {
+  objectId?: string
+  objectType?: string
+  initialSharedVersion?: string
+}
+
+const resolveKeepTemp = () => process.env.SUI_IT_KEEP_TEMP === "1"
+
+const resolveWithFaucet = () => process.env.SUI_IT_WITH_FAUCET !== "0"
+
+const resolveOwnerScriptPath = (scriptName: string) =>
+  path.join(
+    resolveDappRoot(),
+    "src",
+    "scripts",
+    "owner",
+    scriptName.endsWith(".ts") ? scriptName : `${scriptName}.ts`
+  )
+
+const resolveObjectArtifactsPath = (artifactsDir: string) =>
+  path.join(artifactsDir, "objects.localnet.json")
+
+const readObjectArtifacts = async (artifactsDir: string) => {
+  const contents = await readFile(
+    resolveObjectArtifactsPath(artifactsDir),
+    "utf8"
+  )
+  return JSON.parse(contents) as ObjectArtifact[]
+}
+
+const findObjectArtifactById = (
+  artifacts: ObjectArtifact[],
+  objectId: string
+) => artifacts.find((artifact) => artifact.objectId === objectId)
+
+const testEnv = createSuiLocalnetTestEnv({
+  mode: "test",
+  keepTemp: resolveKeepTemp(),
+  withFaucet: resolveWithFaucet(),
+  moveSourceRootPath: resolveDappMoveRoot()
+})
+
+describe("owner amm-create integration", () => {
+  it("creates a shared AMM config and records artifacts", async () => {
+    await testEnv.withTestContext("owner-amm-create", async (context) => {
+      const publisher = context.createAccount("publisher")
+      await context.fundAccount(publisher, { minimumCoinObjects: 2 })
+
+      const publishArtifacts = await context.publishPackage(
+        "prop-amm",
+        publisher,
+        { withUnpublishedDependencies: true }
+      )
+      pickRootNonDependencyArtifact(publishArtifacts)
+
+      const baseSpreadBps = "37"
+      const volatilityMultiplierBps = "420"
+      const useLaser = true
+      const pythPriceFeedId = DEFAULT_MOCK_PRICE_FEED.feedIdHex
+
+      const scriptRunner = createSuiScriptRunner(context)
+      const result = await scriptRunner.runScript(
+        resolveOwnerScriptPath("amm-create"),
+        {
+          account: publisher,
+          args: {
+            json: true,
+            baseSpreadBps,
+            volatilityMultiplierBps,
+            useLaser,
+            pythPriceFeedId
+          }
+        }
+      )
+
+      expect(result.exitCode).toBe(0)
+
+      const output = parseJsonFromScriptOutput<AmmCreateOutput>(
+        result.stdout,
+        "amm-create output"
+      )
+      if (!output.ammConfig)
+        throw new Error("amm-create output did not include ammConfig.")
+      if (!output.initialSharedVersion)
+        throw new Error("amm-create output did not include shared version.")
+
+      expect(output.digest).toBeTruthy()
+      expect(output.transactionSummary?.label).toBe("create-amm")
+      expect(output.ammConfig.baseSpreadBps).toBe(baseSpreadBps)
+      expect(output.ammConfig.volatilityMultiplierBps).toBe(
+        volatilityMultiplierBps
+      )
+      expect(output.ammConfig.useLaser).toBe(useLaser)
+      expect(output.ammConfig.tradingPaused).toBe(false)
+      expect(normalizeHex(output.ammConfig.pythPriceFeedIdHex)).toBe(
+        normalizeHex(pythPriceFeedId)
+      )
+      expect(normalizeHex(output.pythPriceFeedIdHex ?? "")).toBe(
+        normalizeHex(pythPriceFeedId)
+      )
+
+      const objectResponse = await context.suiClient.getObject({
+        id: output.ammConfig.configId,
+        options: { showOwner: true }
+      })
+      if (!objectResponse.data)
+        throw new Error("AMM config object could not be loaded from localnet.")
+      const onChainSharedVersion = extractInitialSharedVersion(
+        objectResponse.data
+      )
+
+      expect(onChainSharedVersion).toBe(output.initialSharedVersion)
+
+      const objectArtifacts = await readObjectArtifacts(context.artifactsDir)
+      const createdArtifact = findObjectArtifactById(
+        objectArtifacts,
+        output.ammConfig.configId
+      )
+      expect(
+        createdArtifact?.objectType?.endsWith(AMM_CONFIG_TYPE_SUFFIX)
+      ).toBe(true)
+      expect(createdArtifact?.initialSharedVersion).toBe(
+        output.initialSharedVersion
+      )
+    })
+  })
+})

--- a/packages/dapp/src/scripts/user/amm-view.ts
+++ b/packages/dapp/src/scripts/user/amm-view.ts
@@ -1,0 +1,96 @@
+/**
+ * Displays the current AMM config snapshot for the target network.
+ * Resolves the config id from artifacts when omitted.
+ */
+import yargs from "yargs"
+
+import {
+  collectAmmConfigSnapshot,
+  resolveAmmConfigId
+} from "@sui-amm/domain-node/amm"
+import { emitJsonOutput } from "@sui-amm/tooling-node/json"
+import { logKeyValueBlue } from "@sui-amm/tooling-node/log"
+import { runSuiScript } from "@sui-amm/tooling-node/process"
+import { logAmmConfigOverview } from "../../utils/amm.ts"
+
+type AmmViewArguments = {
+  ammConfigId?: string
+  json?: boolean
+}
+
+type AmmViewContext = {
+  networkName: string
+  rpcUrl: string
+  ammConfigId: string
+}
+
+const resolveAmmConfigIdToView = async ({
+  networkName,
+  cliArguments
+}: {
+  networkName: string
+  cliArguments: AmmViewArguments
+}): Promise<string> =>
+  resolveAmmConfigId({
+    networkName,
+    ammConfigId: cliArguments.ammConfigId
+  })
+
+const logAmmViewContext = ({
+  networkName,
+  rpcUrl,
+  ammConfigId
+}: AmmViewContext) => {
+  logKeyValueBlue("Network")(networkName)
+  logKeyValueBlue("RPC")(rpcUrl)
+  logKeyValueBlue("Config")(ammConfigId)
+  console.log("")
+}
+
+runSuiScript(
+  async (tooling, cliArguments: AmmViewArguments) => {
+    const ammConfigId = await resolveAmmConfigIdToView({
+      networkName: tooling.network.networkName,
+      cliArguments
+    })
+
+    const { ammConfigOverview, initialSharedVersion } =
+      await collectAmmConfigSnapshot({
+        tooling,
+        ammConfigId
+      })
+
+    if (
+      emitJsonOutput(
+        {
+          ammConfig: ammConfigOverview,
+          initialSharedVersion
+        },
+        cliArguments.json
+      )
+    )
+      return
+
+    logAmmViewContext({
+      networkName: tooling.network.networkName,
+      rpcUrl: tooling.network.url,
+      ammConfigId
+    })
+
+    logAmmConfigOverview(ammConfigOverview, { initialSharedVersion })
+  },
+  yargs()
+    .option("ammConfigId", {
+      alias: ["amm-config-id", "config-id"],
+      type: "string",
+      description:
+        "AMM config object id; inferred from the latest objects artifact when omitted.",
+      demandOption: false
+    })
+    .option("json", {
+      type: "boolean",
+      default: false,
+      description: "Output results as JSON."
+    })
+    .strict()
+)

--- a/packages/dapp/src/scripts/user/test-integration/amm-view.test.ts
+++ b/packages/dapp/src/scripts/user/test-integration/amm-view.test.ts
@@ -1,0 +1,127 @@
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+import {
+  AMM_CONFIG_TYPE_SUFFIX,
+  type AmmConfigOverview
+} from "@sui-amm/domain-core/models/amm"
+import { DEFAULT_MOCK_PRICE_FEED } from "@sui-amm/domain-core/models/pyth"
+import {
+  buildCreateAmmConfigTransaction,
+  parsePythPriceFeedIdBytes
+} from "@sui-amm/domain-core/ptb/amm"
+import { normalizeHex } from "@sui-amm/tooling-core/hex"
+import { extractInitialSharedVersion } from "@sui-amm/tooling-core/shared-object"
+import { ensureCreatedObject } from "@sui-amm/tooling-core/transactions"
+import { pickRootNonDependencyArtifact } from "@sui-amm/tooling-node/artifacts"
+import { createSuiLocalnetTestEnv } from "@sui-amm/tooling-node/testing/env"
+import {
+  resolveDappMoveRoot,
+  resolveDappRoot
+} from "@sui-amm/tooling-node/testing/paths"
+import {
+  createSuiScriptRunner,
+  parseJsonFromScriptOutput
+} from "@sui-amm/tooling-node/testing/scripts"
+
+type AmmViewOutput = {
+  ammConfig?: AmmConfigOverview
+  initialSharedVersion?: string
+}
+
+const resolveKeepTemp = () => process.env.SUI_IT_KEEP_TEMP === "1"
+
+const resolveWithFaucet = () => process.env.SUI_IT_WITH_FAUCET !== "0"
+
+const resolveUserScriptPath = (scriptName: string) =>
+  path.join(
+    resolveDappRoot(),
+    "src",
+    "scripts",
+    "user",
+    scriptName.endsWith(".ts") ? scriptName : `${scriptName}.ts`
+  )
+
+const testEnv = createSuiLocalnetTestEnv({
+  mode: "test",
+  keepTemp: resolveKeepTemp(),
+  withFaucet: resolveWithFaucet(),
+  moveSourceRootPath: resolveDappMoveRoot()
+})
+
+describe("amm-view script", () => {
+  it("renders the latest AMM config snapshot when no id is provided", async () => {
+    await testEnv.withTestContext("user-amm-view", async (context) => {
+      const publisher = context.createAccount("publisher")
+      await context.fundAccount(publisher, { minimumCoinObjects: 2 })
+
+      const publishArtifacts = await context.publishPackage(
+        "prop-amm",
+        publisher,
+        { withUnpublishedDependencies: true }
+      )
+      const rootArtifact = pickRootNonDependencyArtifact(publishArtifacts)
+
+      const baseSpreadBps = 37n
+      const volatilityMultiplierBps = 420n
+      const useLaser = true
+      const pythPriceFeedIdHex = DEFAULT_MOCK_PRICE_FEED.feedIdHex
+      const createTransaction = buildCreateAmmConfigTransaction({
+        packageId: rootArtifact.packageId,
+        baseSpreadBps,
+        volatilityMultiplierBps,
+        useLaser,
+        pythPriceFeedIdBytes: parsePythPriceFeedIdBytes(pythPriceFeedIdHex)
+      })
+
+      const createResult = await context.signAndExecuteTransaction(
+        createTransaction,
+        publisher
+      )
+      await context.waitForFinality(createResult.digest)
+
+      const createdConfig = ensureCreatedObject(
+        AMM_CONFIG_TYPE_SUFFIX,
+        createResult
+      )
+      const ammConfigId = createdConfig.objectId
+      const initialSharedVersion = extractInitialSharedVersion(createdConfig)
+      if (!initialSharedVersion)
+        throw new Error(
+          "Expected AMM config to include shared version metadata."
+        )
+
+      const scriptRunner = createSuiScriptRunner(context)
+      const result = await scriptRunner.runScript(
+        resolveUserScriptPath("amm-view"),
+        {
+          account: publisher,
+          args: { json: true }
+        }
+      )
+
+      expect(result.exitCode).toBe(0)
+
+      const parsed = parseJsonFromScriptOutput<AmmViewOutput>(
+        result.stdout,
+        "amm-view output"
+      )
+      if (!parsed.ammConfig)
+        throw new Error("amm-view output did not include ammConfig.")
+      if (!parsed.initialSharedVersion)
+        throw new Error("amm-view output did not include shared version.")
+
+      expect(parsed.ammConfig.configId).toBe(ammConfigId)
+      expect(parsed.ammConfig.baseSpreadBps).toBe(baseSpreadBps.toString())
+      expect(parsed.ammConfig.volatilityMultiplierBps).toBe(
+        volatilityMultiplierBps.toString()
+      )
+      expect(parsed.ammConfig.useLaser).toBe(useLaser)
+      expect(parsed.ammConfig.tradingPaused).toBe(false)
+      expect(normalizeHex(parsed.ammConfig.pythPriceFeedIdHex)).toBe(
+        normalizeHex(pythPriceFeedIdHex)
+      )
+      expect(parsed.initialSharedVersion).toBe(initialSharedVersion)
+    })
+  })
+})

--- a/packages/dapp/src/utils/amm.ts
+++ b/packages/dapp/src/utils/amm.ts
@@ -1,0 +1,141 @@
+import type { SuiClient } from "@mysten/sui/client"
+import {
+  AMM_ADMIN_CAP_TYPE_SUFFIX,
+  type AmmConfigOverview
+} from "@sui-amm/domain-core/models/amm"
+import { findMockPriceFeedConfig } from "@sui-amm/domain-core/models/pyth"
+import type { PublishArtifact } from "@sui-amm/tooling-core/types"
+import { ensureCreatedObject } from "@sui-amm/tooling-core/transactions"
+import {
+  findLatestArtifactThat,
+  loadDeploymentArtifacts,
+  readArtifact
+} from "@sui-amm/tooling-node/artifacts"
+import type { Tooling } from "@sui-amm/tooling-node/factory"
+import { logKeyValueGreen, logWarning } from "@sui-amm/tooling-node/log"
+import { resolveFullPackagePath } from "@sui-amm/tooling-node/move"
+import type { MockArtifact } from "./mocks.ts"
+import { mockArtifactPath } from "./mocks.ts"
+
+export const DEFAULT_PYTH_PRICE_FEED_LABEL = "MOCK_SUI_FEED"
+
+const AMM_PACKAGE_FOLDER_NAME = "prop-amm"
+
+export const resolveAmmPackagePath = (tooling: Tooling) =>
+  resolveFullPackagePath(tooling.suiConfig.paths.move, AMM_PACKAGE_FOLDER_NAME)
+
+const resolveAmmPublishArtifact = async ({
+  networkName,
+  ammPackageId
+}: {
+  networkName: string
+  ammPackageId: string
+}): Promise<PublishArtifact | undefined> => {
+  const deploymentArtifacts = await loadDeploymentArtifacts(networkName)
+
+  return findLatestArtifactThat(
+    (artifact) => artifact.packageId === ammPackageId,
+    deploymentArtifacts
+  )
+}
+
+export const resolveAmmAdminCapIdFromPublishDigest = async ({
+  publishDigest,
+  suiClient
+}: {
+  publishDigest: string
+  suiClient: SuiClient
+}): Promise<string> => {
+  const publishTransaction = await suiClient.getTransactionBlock({
+    digest: publishDigest,
+    options: { showObjectChanges: true }
+  })
+
+  return ensureCreatedObject(AMM_ADMIN_CAP_TYPE_SUFFIX, publishTransaction)
+    .objectId
+}
+
+export const resolveAmmAdminCapIdFromArtifacts = async ({
+  tooling,
+  ammPackageId
+}: {
+  tooling: Pick<Tooling, "suiClient" | "network">
+  ammPackageId: string
+}): Promise<string> => {
+  const publishArtifact = await resolveAmmPublishArtifact({
+    networkName: tooling.network.networkName,
+    ammPackageId
+  })
+
+  if (!publishArtifact?.digest)
+    throw new Error(
+      "Unable to locate the latest AMM publish artifact; provide --admin-cap-id or re-run publish to refresh deployments."
+    )
+
+  return resolveAmmAdminCapIdFromPublishDigest({
+    publishDigest: publishArtifact.digest,
+    suiClient: tooling.suiClient
+  })
+}
+
+const findPriceFeedIdFromMockArtifact = (
+  mockArtifact: MockArtifact,
+  label: string
+): string | undefined =>
+  mockArtifact.priceFeeds?.find((feed) => feed.label === label)?.feedIdHex
+
+export const resolvePythPriceFeedIdHex = async ({
+  networkName,
+  pythPriceFeedId,
+  pythPriceFeedLabel
+}: {
+  networkName: string
+  pythPriceFeedId?: string
+  pythPriceFeedLabel?: string
+}): Promise<string> => {
+  const trimmedFeedId = pythPriceFeedId?.trim()
+  if (trimmedFeedId) return trimmedFeedId
+
+  if (networkName !== "localnet")
+    throw new Error(
+      "Pyth price feed id is required; provide --pyth-price-feed-id when targeting shared networks."
+    )
+
+  const desiredLabel = pythPriceFeedLabel ?? DEFAULT_PYTH_PRICE_FEED_LABEL
+  const mockArtifact = await readArtifact<MockArtifact>(mockArtifactPath, {})
+
+  const artifactFeedId = findPriceFeedIdFromMockArtifact(
+    mockArtifact,
+    desiredLabel
+  )
+  if (artifactFeedId) return artifactFeedId
+
+  const fallbackFeed = findMockPriceFeedConfig({ label: desiredLabel })
+  if (fallbackFeed) {
+    logWarning(
+      `No localnet mock feed artifacts found for ${desiredLabel}; using default mock feed id.`
+    )
+    return fallbackFeed.feedIdHex
+  }
+
+  throw new Error(
+    "Unable to resolve a Pyth price feed id. Run the mock setup script or provide --pyth-price-feed-id."
+  )
+}
+
+export const logAmmConfigOverview = (
+  overview: AmmConfigOverview,
+  options?: {
+    initialSharedVersion?: string
+  }
+) => {
+  logKeyValueGreen("Config")(overview.configId)
+  logKeyValueGreen("Spread-bps")(overview.baseSpreadBps)
+  logKeyValueGreen("Vol-bps")(overview.volatilityMultiplierBps)
+  logKeyValueGreen("Use-laser")(overview.useLaser ? "Yes" : "No")
+  logKeyValueGreen("Paused")(overview.tradingPaused ? "Yes" : "No")
+  logKeyValueGreen("Feed-id")(overview.pythPriceFeedIdHex)
+  if (options?.initialSharedVersion)
+    logKeyValueGreen("Shared-ver")(options.initialSharedVersion)
+  console.log("")
+}

--- a/packages/dapp/src/utils/test/amm.test.ts
+++ b/packages/dapp/src/utils/test/amm.test.ts
@@ -1,0 +1,112 @@
+import type * as ArtifactsModule from "@sui-amm/tooling-node/artifacts"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const artifactMocks = vi.hoisted(() => ({
+  readArtifact: vi.fn()
+}))
+
+const pythMocks = vi.hoisted(() => ({
+  findMockPriceFeedConfig: vi.fn()
+}))
+
+const logMocks = vi.hoisted(() => ({
+  logWarning: vi.fn(),
+  logKeyValueGreen: vi.fn(() => vi.fn())
+}))
+
+vi.mock("@sui-amm/tooling-node/artifacts", async (importOriginal) => ({
+  ...(await importOriginal<typeof ArtifactsModule>()),
+  readArtifact: artifactMocks.readArtifact
+}))
+
+vi.mock("@sui-amm/domain-core/models/pyth", () => ({
+  findMockPriceFeedConfig: pythMocks.findMockPriceFeedConfig
+}))
+
+vi.mock("@sui-amm/tooling-node/log", () => ({
+  logWarning: logMocks.logWarning,
+  logKeyValueGreen: logMocks.logKeyValueGreen
+}))
+
+import { resolvePythPriceFeedIdHex } from "../amm.ts"
+
+describe("resolvePythPriceFeedIdHex", () => {
+  beforeEach(() => {
+    artifactMocks.readArtifact.mockReset()
+    pythMocks.findMockPriceFeedConfig.mockReset()
+    logMocks.logWarning.mockReset()
+  })
+
+  it("returns a trimmed explicit feed id", async () => {
+    const resolved = await resolvePythPriceFeedIdHex({
+      networkName: "testnet",
+      pythPriceFeedId: " 0xabc "
+    })
+
+    expect(resolved).toBe("0xabc")
+    expect(artifactMocks.readArtifact).not.toHaveBeenCalled()
+    expect(pythMocks.findMockPriceFeedConfig).not.toHaveBeenCalled()
+  })
+
+  it("throws on shared networks without an explicit feed id", async () => {
+    await expect(
+      resolvePythPriceFeedIdHex({ networkName: "devnet" })
+    ).rejects.toThrow(
+      "Pyth price feed id is required; provide --pyth-price-feed-id when targeting shared networks."
+    )
+
+    expect(artifactMocks.readArtifact).not.toHaveBeenCalled()
+  })
+
+  it("prefers mock artifact feed ids on localnet", async () => {
+    artifactMocks.readArtifact.mockResolvedValue({
+      priceFeeds: [
+        {
+          label: "CUSTOM_FEED",
+          feedIdHex: "0xfeed",
+          priceInfoObjectId: "0xprice"
+        }
+      ]
+    })
+
+    const resolved = await resolvePythPriceFeedIdHex({
+      networkName: "localnet",
+      pythPriceFeedLabel: "CUSTOM_FEED"
+    })
+
+    expect(resolved).toBe("0xfeed")
+    expect(pythMocks.findMockPriceFeedConfig).not.toHaveBeenCalled()
+    expect(logMocks.logWarning).not.toHaveBeenCalled()
+  })
+
+  it("falls back to default mocks when artifacts are missing", async () => {
+    artifactMocks.readArtifact.mockResolvedValue({ priceFeeds: [] })
+    pythMocks.findMockPriceFeedConfig.mockReturnValue({
+      label: "MOCK_SUI_FEED",
+      feedIdHex: "0xfallback",
+      price: 1n,
+      confidence: 1n,
+      exponent: 0
+    })
+
+    const resolved = await resolvePythPriceFeedIdHex({
+      networkName: "localnet"
+    })
+
+    expect(resolved).toBe("0xfallback")
+    expect(logMocks.logWarning).toHaveBeenCalledWith(
+      "No localnet mock feed artifacts found for MOCK_SUI_FEED; using default mock feed id."
+    )
+  })
+
+  it("throws when no feed id can be resolved", async () => {
+    artifactMocks.readArtifact.mockResolvedValue({ priceFeeds: [] })
+    pythMocks.findMockPriceFeedConfig.mockReturnValue(undefined)
+
+    await expect(
+      resolvePythPriceFeedIdHex({ networkName: "localnet" })
+    ).rejects.toThrow(
+      "Unable to resolve a Pyth price feed id. Run the mock setup script or provide --pyth-price-feed-id."
+    )
+  })
+})

--- a/packages/domain/core/src/models/amm.ts
+++ b/packages/domain/core/src/models/amm.ts
@@ -1,0 +1,130 @@
+import type { SuiClient, SuiObjectData } from "@mysten/sui/client"
+
+import {
+  getSuiObject,
+  unwrapMoveObjectFields
+} from "@sui-amm/tooling-core/object"
+import {
+  formatOptionalNumericValue,
+  formatVectorBytesAsHex
+} from "@sui-amm/tooling-core/utils/formatters"
+import {
+  parseNonNegativeU64,
+  parsePositiveU64
+} from "@sui-amm/tooling-core/utils/utility"
+import { parsePythPriceFeedIdBytes } from "../ptb/amm.ts"
+
+export const AMM_CONFIG_TYPE_SUFFIX = "::manager::AMMConfig"
+export const AMM_ADMIN_CAP_TYPE_SUFFIX = "::manager::AMMAdminCap"
+
+export type AmmConfigOverview = {
+  configId: string
+  baseSpreadBps: string
+  volatilityMultiplierBps: string
+  useLaser: boolean
+  tradingPaused: boolean
+  pythPriceFeedIdHex: string
+}
+
+type AmmConfigFields = {
+  base_spread_bps?: unknown
+  volatility_multiplier_bps?: unknown
+  use_laser?: unknown
+  trading_paused?: unknown
+  pyth_price_feed_id?: unknown
+}
+
+const requireNumericField = (value: unknown, label: string): string => {
+  const formatted = formatOptionalNumericValue(value)
+  if (formatted === undefined) throw new Error(`${label} is required.`)
+  return formatted
+}
+
+const requireBooleanField = (value: unknown, label: string): boolean => {
+  if (typeof value === "boolean") return value
+  throw new Error(`${label} is required.`)
+}
+
+const requireFeedIdHex = (value: unknown): string => {
+  const formatted = formatVectorBytesAsHex(value)
+  if (formatted === "Unknown")
+    throw new Error("Pyth price feed id is required.")
+  return formatted
+}
+
+const buildAmmConfigOverviewFromObject = ({
+  configId,
+  object
+}: {
+  configId: string
+  object: SuiObjectData
+}): AmmConfigOverview => {
+  const fields = unwrapMoveObjectFields<AmmConfigFields>(object)
+
+  return {
+    configId,
+    baseSpreadBps: requireNumericField(
+      fields.base_spread_bps,
+      "Base spread bps"
+    ),
+    volatilityMultiplierBps: requireNumericField(
+      fields.volatility_multiplier_bps,
+      "Volatility multiplier bps"
+    ),
+    useLaser: requireBooleanField(fields.use_laser, "Use laser flag"),
+    tradingPaused: requireBooleanField(fields.trading_paused, "Trading paused"),
+    pythPriceFeedIdHex: requireFeedIdHex(fields.pyth_price_feed_id)
+  }
+}
+
+export const getAmmConfigOverview = async (
+  configId: string,
+  suiClient: SuiClient
+): Promise<AmmConfigOverview> => {
+  const { object } = await getSuiObject(
+    { objectId: configId, options: { showContent: true, showType: true } },
+    { suiClient }
+  )
+
+  return buildAmmConfigOverviewFromObject({ configId, object })
+}
+
+export const DEFAULT_BASE_SPREAD_BPS = "25"
+export const DEFAULT_VOLATILITY_MULTIPLIER_BPS = "200"
+
+const resolveBaseSpreadBps = (rawValue?: string): bigint =>
+  parsePositiveU64(rawValue ?? DEFAULT_BASE_SPREAD_BPS, "Base spread bps")
+
+const resolveVolatilityMultiplierBps = (rawValue?: string): bigint =>
+  parseNonNegativeU64(
+    rawValue ?? DEFAULT_VOLATILITY_MULTIPLIER_BPS,
+    "Volatility multiplier bps"
+  )
+
+const resolveUseLaserFlag = (rawValue?: boolean): boolean => rawValue ?? false
+
+export const resolveAmmConfigInputs = async ({
+  volatilityMultiplierBps,
+  baseSpreadBps,
+  useLaser,
+  pythPriceFeedIdHex
+}: {
+  volatilityMultiplierBps?: string
+  baseSpreadBps?: string
+  useLaser?: boolean
+  pythPriceFeedIdHex: string
+}): Promise<{
+  baseSpreadBps: bigint
+  volatilityMultiplierBps: bigint
+  useLaser: boolean
+  pythPriceFeedIdHex: string
+  pythPriceFeedIdBytes: number[]
+}> => ({
+  baseSpreadBps: resolveBaseSpreadBps(baseSpreadBps),
+  volatilityMultiplierBps: resolveVolatilityMultiplierBps(
+    volatilityMultiplierBps
+  ),
+  useLaser: resolveUseLaserFlag(useLaser),
+  pythPriceFeedIdHex,
+  pythPriceFeedIdBytes: parsePythPriceFeedIdBytes(pythPriceFeedIdHex)
+})

--- a/packages/domain/core/src/ptb/amm.ts
+++ b/packages/domain/core/src/ptb/amm.ts
@@ -1,0 +1,91 @@
+import { assertBytesLength, hexToBytes } from "@sui-amm/tooling-core/hex"
+import type { WrappedSuiSharedObject } from "@sui-amm/tooling-core/shared-object"
+import { newTransaction } from "@sui-amm/tooling-core/transactions"
+import { validateRequiredHexBytes } from "@sui-amm/tooling-core/utils/validation"
+
+const PYTH_PRICE_FEED_ID_BYTES = 32
+
+export const parsePythPriceFeedIdBytes = (
+  pythPriceFeedIdHex: string
+): number[] => {
+  const trimmed = pythPriceFeedIdHex.trim()
+  const validationError = validateRequiredHexBytes({
+    value: trimmed,
+    expectedBytes: PYTH_PRICE_FEED_ID_BYTES,
+    label: "Pyth price feed id"
+  })
+  if (validationError) throw new Error(validationError)
+
+  return assertBytesLength(hexToBytes(trimmed), PYTH_PRICE_FEED_ID_BYTES)
+}
+
+export const buildCreateAmmConfigTransaction = ({
+  packageId,
+  baseSpreadBps,
+  volatilityMultiplierBps,
+  useLaser,
+  pythPriceFeedIdBytes
+}: {
+  packageId: string
+  baseSpreadBps: bigint | number
+  volatilityMultiplierBps: bigint | number
+  useLaser: boolean
+  pythPriceFeedIdBytes: number[]
+}) => {
+  const transaction = newTransaction()
+
+  const config = transaction.moveCall({
+    target: `${packageId}::manager::create_amm_config`,
+    arguments: [
+      transaction.pure.u64(baseSpreadBps),
+      transaction.pure.u64(volatilityMultiplierBps),
+      transaction.pure.bool(useLaser),
+      transaction.pure.vector("u8", pythPriceFeedIdBytes)
+    ]
+  })
+
+  transaction.moveCall({
+    target: `${packageId}::manager::share_amm_config`,
+    arguments: [config]
+  })
+
+  return transaction
+}
+
+export const buildUpdateAmmConfigTransaction = ({
+  packageId,
+  adminCapId,
+  config,
+  baseSpreadBps,
+  volatilityMultiplierBps,
+  useLaser,
+  tradingPaused,
+  pythPriceFeedIdBytes
+}: {
+  packageId: string
+  adminCapId: string
+  config: WrappedSuiSharedObject
+  baseSpreadBps: bigint | number
+  volatilityMultiplierBps: bigint | number
+  useLaser: boolean
+  tradingPaused: boolean
+  pythPriceFeedIdBytes: number[]
+}) => {
+  const transaction = newTransaction()
+  const configArgument = transaction.sharedObjectRef(config.sharedRef)
+
+  transaction.moveCall({
+    target: `${packageId}::manager::update_amm_config`,
+    arguments: [
+      configArgument,
+      transaction.object(adminCapId),
+      transaction.pure.u64(baseSpreadBps),
+      transaction.pure.u64(volatilityMultiplierBps),
+      transaction.pure.bool(useLaser),
+      transaction.pure.bool(tradingPaused),
+      transaction.pure.vector("u8", pythPriceFeedIdBytes)
+    ]
+  })
+
+  return transaction
+}

--- a/packages/domain/node/src/amm.ts
+++ b/packages/domain/node/src/amm.ts
@@ -1,0 +1,96 @@
+import type { AmmConfigOverview } from "@sui-amm/domain-core/models/amm"
+import {
+  AMM_ADMIN_CAP_TYPE_SUFFIX,
+  AMM_CONFIG_TYPE_SUFFIX,
+  getAmmConfigOverview
+} from "@sui-amm/domain-core/models/amm"
+import { normalizeIdOrThrow } from "@sui-amm/tooling-core/object"
+import type { PublishArtifact } from "@sui-amm/tooling-core/types"
+import {
+  findLatestArtifactThat,
+  getLatestObjectFromArtifact,
+  isPublishArtifactNamed,
+  loadDeploymentArtifacts
+} from "@sui-amm/tooling-node/artifacts"
+import type { Tooling } from "@sui-amm/tooling-node/factory"
+
+const AMM_PACKAGE_NAME = "amm"
+
+export const isAmmPublishArtifact = (artifact: PublishArtifact) =>
+  isPublishArtifactNamed(AMM_PACKAGE_NAME)(artifact)
+
+export const resolveAmmPackageId = async ({
+  networkName,
+  ammPackageId
+}: {
+  networkName: string
+  ammPackageId?: string
+}): Promise<string> => {
+  const deploymentArtifacts = await loadDeploymentArtifacts(networkName)
+  const latestAmmPublishArtifact = findLatestArtifactThat(
+    isAmmPublishArtifact,
+    deploymentArtifacts
+  )
+
+  return normalizeIdOrThrow(
+    ammPackageId ?? latestAmmPublishArtifact?.packageId,
+    "An AMM package id is required; publish the package or provide --amm-package-id."
+  )
+}
+
+export const resolveAmmConfigId = async ({
+  networkName,
+  ammConfigId
+}: {
+  networkName: string
+  ammConfigId?: string
+}): Promise<string> => {
+  const latestConfigArtifact = await getLatestObjectFromArtifact(
+    AMM_CONFIG_TYPE_SUFFIX
+  )(networkName)
+
+  return normalizeIdOrThrow(
+    ammConfigId ?? latestConfigArtifact?.objectId,
+    "An AMM config id is required; create an AMM config first or provide --amm-config-id."
+  )
+}
+
+export const resolveAmmAdminCapId = async ({
+  networkName,
+  adminCapId
+}: {
+  networkName: string
+  adminCapId?: string
+}): Promise<string> => {
+  const latestAdminCapArtifact = await getLatestObjectFromArtifact(
+    AMM_ADMIN_CAP_TYPE_SUFFIX
+  )(networkName)
+
+  return normalizeIdOrThrow(
+    adminCapId ?? latestAdminCapArtifact?.objectId,
+    "An AMM admin cap id is required; publish the package or provide --admin-cap-id."
+  )
+}
+
+export type AmmConfigSnapshot = {
+  ammConfigOverview: AmmConfigOverview
+  initialSharedVersion: string
+}
+
+export const collectAmmConfigSnapshot = async ({
+  tooling,
+  ammConfigId
+}: {
+  tooling: Pick<Tooling, "suiClient" | "getImmutableSharedObject">
+  ammConfigId: string
+}): Promise<AmmConfigSnapshot> => {
+  const [ammConfigOverview, sharedObject] = await Promise.all([
+    getAmmConfigOverview(ammConfigId, tooling.suiClient),
+    tooling.getImmutableSharedObject({ objectId: ammConfigId })
+  ])
+
+  return {
+    ammConfigOverview,
+    initialSharedVersion: sharedObject.sharedRef.initialSharedVersion
+  }
+}


### PR DESCRIPTION
Fixes #25

## Summary
Adds the AMM config management module in TypeScript: domain model parsing, PTB builders, and create/view script flows.

## Scope
- Domain model for AMM config object reads
- PTB builders for create/update transactions
- Node-side artifact resolvers for package/config lookup
- Owner `amm-create` and user `amm-view` scripts
- Integration coverage for create/view flow

## Notes
This branch builds on contract-level manager support from earlier stack PRs.
