### PR TITLE
Add admin configuration panel for spread and volatility

### DIFF
--- a/packages/ui/src/app/components/AmmConfigCard.tsx
+++ b/packages/ui/src/app/components/AmmConfigCard.tsx
@@ -1,12 +1,37 @@
 "use client"
 
+import { useState } from "react"
 import useAmmConfigCardViewModel from "../hooks/useAmmConfigCardViewModel"
 import AmmConfigCardView from "./AmmConfigCardView"
+import UpdateAmmConfigModal from "./UpdateAmmConfigModal"
 
 const AmmConfigCard = () => {
-  const { viewModel } = useAmmConfigCardViewModel()
+  const { viewModel, ammConfig, canUpdateConfig, applyAmmConfigUpdate } =
+    useAmmConfigCardViewModel()
+  const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false)
+  const handleOpenUpdateModal = canUpdateConfig
+    ? () => setIsUpdateModalOpen(true)
+    : undefined
 
-  return <AmmConfigCardView {...viewModel} />
+  return (
+    <>
+      <AmmConfigCardView
+        {...viewModel}
+        onOpenUpdateModal={handleOpenUpdateModal}
+      />
+      <UpdateAmmConfigModal
+        open={isUpdateModalOpen}
+        ammConfigId={viewModel.ammConfigId}
+        ammConfig={ammConfig}
+        networkLabel={viewModel.networkLabel}
+        explorerUrl={viewModel.explorerUrl}
+        onClose={() => setIsUpdateModalOpen(false)}
+        onConfigUpdated={(updatedConfig) => {
+          applyAmmConfigUpdate(updatedConfig)
+        }}
+      />
+    </>
+  )
 }
 
 export default AmmConfigCard

--- a/packages/ui/src/app/components/AmmConfigCardView.tsx
+++ b/packages/ui/src/app/components/AmmConfigCardView.tsx
@@ -5,6 +5,7 @@ import type {
   TAmmConfigCardContent,
   TAmmConfigCardViewModel
 } from "../types/TAmmConfigCard"
+import Button from "./Button"
 import CopyableId from "./CopyableId"
 import Loading from "./Loading"
 
@@ -93,8 +94,15 @@ const AmmConfigCardView = ({
   description,
   explorerUrl,
   ammConfigId,
-  content
-}: TAmmConfigCardViewModel) => {
+  content,
+  onOpenUpdateModal,
+  updateDisabled,
+  updateTooltip
+}: TAmmConfigCardViewModel & {
+  onOpenUpdateModal?: () => void
+  updateDisabled?: boolean
+  updateTooltip?: string
+}) => {
   return (
     <section className="w-full max-w-4xl px-4">
       <div className="rounded-2xl border border-slate-300/80 bg-white/90 shadow-[0_22px_65px_-45px_rgba(15,23,42,0.45)] backdrop-blur-md transition dark:border-slate-50/30 dark:bg-slate-950/70">
@@ -107,6 +115,19 @@ const AmmConfigCardView = ({
               {description}
             </p>
           </div>
+          {onOpenUpdateModal ? (
+            <div className="ml-auto flex items-center">
+              <Button
+                variant="secondary"
+                size="compact"
+                onClick={onOpenUpdateModal}
+                disabled={updateDisabled}
+                tooltip={updateTooltip}
+              >
+                Update config
+              </Button>
+            </div>
+          ) : undefined}
         </div>
         <div className="space-y-4 px-6 py-5">
           <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.16em] text-slate-500 dark:text-slate-200/60">

--- a/packages/ui/src/app/components/UpdateAmmConfigModal.tsx
+++ b/packages/ui/src/app/components/UpdateAmmConfigModal.tsx
@@ -1,0 +1,458 @@
+"use client"
+
+import type { AmmConfigOverview } from "@sui-amm/domain-core/models/amm"
+import clsx from "clsx"
+import { shortenId } from "../helpers/format"
+import {
+  useUpdateAmmConfigModalState,
+  type AmmConfigUpdateSummary
+} from "../hooks/useUpdateAmmConfigModalState"
+import Button from "./Button"
+import CopyableId from "./CopyableId"
+import {
+  ModalBody,
+  ModalErrorFooter,
+  ModalErrorNotice,
+  ModalFrame,
+  ModalHeader,
+  ModalSection,
+  ModalStatusHeader,
+  ModalSuccessFooter,
+  modalFieldDescriptionClassName,
+  modalFieldErrorTextClassName,
+  modalFieldInputClassName,
+  modalFieldInputErrorClassName,
+  modalFieldLabelClassName,
+  modalFieldTitleClassName
+} from "./ModalPrimitives"
+import TransactionRecap from "./TransactionRecap"
+
+const inputClassName = (error?: string) =>
+  [modalFieldInputClassName, error ? modalFieldInputErrorClassName : ""]
+    .filter(Boolean)
+    .join(" ")
+
+const toggleButtonClassName = (active: boolean) =>
+  clsx(
+    "rounded-full border px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] transition",
+    active
+      ? "border-sds-blue/70 bg-sds-blue/15 dark:border-sds-blue/40 dark:bg-sds-blue/20 text-sds-dark dark:text-sds-light"
+      : "border-slate-200/70 text-slate-500 hover:border-slate-300/70 dark:border-slate-50/15 dark:text-slate-200/70 dark:hover:border-slate-50/30"
+  )
+
+const ToggleField = ({
+  title,
+  description,
+  value,
+  activeLabel,
+  inactiveLabel,
+  onChange
+}: {
+  title: string
+  description?: string
+  value: boolean
+  activeLabel: string
+  inactiveLabel: string
+  onChange: (nextValue: boolean) => void
+}) => (
+  <label className={modalFieldLabelClassName}>
+    <span className={modalFieldTitleClassName}>{title}</span>
+    {description ? (
+      <span className={modalFieldDescriptionClassName}>{description}</span>
+    ) : undefined}
+    <div className="mt-2 flex flex-wrap gap-2">
+      <button
+        type="button"
+        className={toggleButtonClassName(value)}
+        onClick={() => onChange(true)}
+      >
+        {activeLabel}
+      </button>
+      <button
+        type="button"
+        className={toggleButtonClassName(!value)}
+        onClick={() => onChange(false)}
+      >
+        {inactiveLabel}
+      </button>
+    </div>
+  </label>
+)
+
+const ConfigValueCard = ({
+  label,
+  value,
+  detail
+}: {
+  label: string
+  value: string
+  detail?: string
+}) => (
+  <div className="rounded-xl border border-slate-200/70 bg-white/80 p-3 text-xs dark:border-slate-50/15 dark:bg-slate-950/60">
+    <div className="text-[0.6rem] uppercase tracking-[0.18em] text-slate-500 dark:text-slate-200/60">
+      {label}
+    </div>
+    <div className="mt-1 text-sm font-semibold text-sds-dark dark:text-sds-light">
+      {value}
+    </div>
+    {detail ? (
+      <div className="mt-2 overflow-auto text-[0.7rem] text-slate-500 dark:text-slate-200/60">
+        {detail}
+      </div>
+    ) : undefined}
+  </div>
+)
+
+const AmmConfigSummarySection = ({
+  summary,
+  explorerUrl
+}: {
+  summary: AmmConfigUpdateSummary
+  explorerUrl?: string
+}) => (
+  <ModalSection
+    title="Updated configuration"
+    subtitle="Latest on-chain values for this AMM"
+  >
+    <div className="grid gap-3 text-xs sm:grid-cols-2">
+      <ConfigValueCard
+        label="Base spread (bps)"
+        value={summary.ammConfig.baseSpreadBps}
+      />
+      <ConfigValueCard
+        label="Volatility multiplier (bps)"
+        value={summary.ammConfig.volatilityMultiplierBps}
+      />
+      <ConfigValueCard
+        label="Laser"
+        value={summary.ammConfig.useLaser ? "Enabled" : "Disabled"}
+      />
+      <ConfigValueCard
+        label="Trading status"
+        value={summary.ammConfig.tradingPaused ? "Paused" : "Live"}
+      />
+      <div className="sm:col-span-2">
+        <ConfigValueCard
+          label="Pyth price feed id"
+          value={shortenId(summary.ammConfig.pythPriceFeedIdHex, 10, 8)}
+          detail={summary.ammConfig.pythPriceFeedIdHex}
+        />
+      </div>
+    </div>
+    <div className="mt-4 flex flex-wrap items-center gap-3 text-xs">
+      <CopyableId
+        value={summary.ammConfig.configId}
+        label="AMM config"
+        explorerUrl={explorerUrl}
+      />
+      <CopyableId
+        value={summary.adminCapId}
+        label="Admin cap"
+        explorerUrl={explorerUrl}
+      />
+    </div>
+  </ModalSection>
+)
+
+const AmmConfigSuccessView = ({
+  summary,
+  explorerUrl,
+  onClose,
+  onReset
+}: {
+  summary: AmmConfigUpdateSummary
+  explorerUrl?: string
+  onClose: () => void
+  onReset: () => void
+}) => (
+  <>
+    <ModalStatusHeader
+      status="success"
+      title="AMM config updated"
+      subtitle={shortenId(summary.ammConfig.configId)}
+      description="The updated settings are now live on-chain."
+      onClose={onClose}
+    />
+    <ModalBody>
+      <AmmConfigSummarySection summary={summary} explorerUrl={explorerUrl} />
+      <TransactionRecap
+        transactionBlock={summary.transactionBlock}
+        digest={summary.digest}
+        explorerUrl={explorerUrl}
+      />
+    </ModalBody>
+    <ModalSuccessFooter
+      actionLabel="Update again"
+      onAction={onReset}
+      onClose={onClose}
+    />
+  </>
+)
+
+const AmmConfigErrorView = ({
+  error,
+  details,
+  onClose,
+  onReset
+}: {
+  error: string
+  details?: string
+  onClose: () => void
+  onReset: () => void
+}) => (
+  <>
+    <ModalStatusHeader
+      status="error"
+      title="AMM update failed"
+      subtitle="Check the details and try again."
+      description="Resolve the issue before resubmitting the update."
+      onClose={onClose}
+    />
+    <ModalBody>
+      <ModalErrorNotice error={error} details={details} />
+    </ModalBody>
+    <ModalErrorFooter onRetry={onReset} onClose={onClose} />
+  </>
+)
+
+const UpdateAmmConfigModal = ({
+  open,
+  ammConfigId,
+  ammConfig,
+  networkLabel,
+  explorerUrl,
+  onClose,
+  onConfigUpdated
+}: {
+  open: boolean
+  ammConfigId?: string
+  ammConfig?: AmmConfigOverview
+  networkLabel: string
+  explorerUrl?: string
+  onClose: () => void
+  onConfigUpdated?: (config: AmmConfigOverview) => void
+}) => {
+  const {
+    formState,
+    fieldErrors,
+    transactionState,
+    transactionSummary,
+    isSuccessState,
+    isErrorState,
+    canSubmit,
+    handleInputChange,
+    markFieldBlur,
+    shouldShowFieldError,
+    handleUpdateAmmConfig,
+    resetForm
+  } = useUpdateAmmConfigModalState({
+    open,
+    ammConfigId,
+    ammConfig,
+    onConfigUpdated
+  })
+
+  if (!open) return <></>
+
+  if (isSuccessState && transactionSummary) {
+    return (
+      <ModalFrame onClose={onClose}>
+        <AmmConfigSuccessView
+          summary={transactionSummary}
+          explorerUrl={explorerUrl}
+          onClose={onClose}
+          onReset={resetForm}
+        />
+      </ModalFrame>
+    )
+  }
+
+  if (isErrorState && transactionState.status === "error") {
+    return (
+      <ModalFrame onClose={onClose}>
+        <AmmConfigErrorView
+          error={transactionState.error}
+          details={transactionState.details}
+          onClose={onClose}
+          onReset={resetForm}
+        />
+      </ModalFrame>
+    )
+  }
+
+  return (
+    <ModalFrame onClose={onClose}>
+      <ModalHeader
+        eyebrow="AMM configuration"
+        title="Update AMM config"
+        description={`Network: ${networkLabel}`}
+        onClose={onClose}
+      />
+      <ModalBody>
+        {ammConfigId ? (
+          <ModalSection
+            title="Target configuration"
+            subtitle="Updates apply to the shared AMM config object."
+          >
+            <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.18em] text-slate-500 dark:text-slate-200/60">
+              <CopyableId
+                value={ammConfigId}
+                label="AMM config"
+                explorerUrl={explorerUrl}
+              />
+            </div>
+          </ModalSection>
+        ) : (
+          <div className="rounded-2xl border border-rose-200/70 bg-rose-50/70 px-4 py-3 text-xs text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200">
+            AMM config ID is not configured for this network.
+          </div>
+        )}
+
+        <ModalSection
+          title="Configuration updates"
+          subtitle="Adjust spreads, trading flags, and oracle feed settings."
+        >
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className={modalFieldLabelClassName}>
+              <span className={modalFieldTitleClassName}>
+                Base spread (bps)
+              </span>
+              <span className={modalFieldDescriptionClassName}>
+                Must be a positive u64.
+              </span>
+              <input
+                value={formState.baseSpreadBps}
+                onChange={(event) =>
+                  handleInputChange("baseSpreadBps", event.target.value)
+                }
+                onBlur={() => markFieldBlur("baseSpreadBps")}
+                className={inputClassName(
+                  shouldShowFieldError(
+                    "baseSpreadBps",
+                    fieldErrors.baseSpreadBps
+                  )
+                    ? fieldErrors.baseSpreadBps
+                    : undefined
+                )}
+                placeholder="25"
+              />
+              {shouldShowFieldError(
+                "baseSpreadBps",
+                fieldErrors.baseSpreadBps
+              ) ? (
+                <span className={modalFieldErrorTextClassName}>
+                  {fieldErrors.baseSpreadBps}
+                </span>
+              ) : undefined}
+            </label>
+
+            <label className={modalFieldLabelClassName}>
+              <span className={modalFieldTitleClassName}>
+                Volatility multiplier (bps)
+              </span>
+              <span className={modalFieldDescriptionClassName}>
+                Zero or higher u64.
+              </span>
+              <input
+                value={formState.volatilityMultiplierBps}
+                onChange={(event) =>
+                  handleInputChange(
+                    "volatilityMultiplierBps",
+                    event.target.value
+                  )
+                }
+                onBlur={() => markFieldBlur("volatilityMultiplierBps")}
+                className={inputClassName(
+                  shouldShowFieldError(
+                    "volatilityMultiplierBps",
+                    fieldErrors.volatilityMultiplierBps
+                  )
+                    ? fieldErrors.volatilityMultiplierBps
+                    : undefined
+                )}
+                placeholder="200"
+              />
+              {shouldShowFieldError(
+                "volatilityMultiplierBps",
+                fieldErrors.volatilityMultiplierBps
+              ) ? (
+                <span className={modalFieldErrorTextClassName}>
+                  {fieldErrors.volatilityMultiplierBps}
+                </span>
+              ) : undefined}
+            </label>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <ToggleField
+              title="Laser pricing"
+              description="Enable or disable the laser pricing path."
+              value={formState.useLaser}
+              activeLabel="Enabled"
+              inactiveLabel="Disabled"
+              onChange={(value) => handleInputChange("useLaser", value)}
+            />
+            <ToggleField
+              title="Trading status"
+              description="Pause trading without changing spreads."
+              value={!formState.tradingPaused}
+              activeLabel="Live"
+              inactiveLabel="Paused"
+              onChange={(value) => handleInputChange("tradingPaused", !value)}
+            />
+          </div>
+
+          <label className={modalFieldLabelClassName}>
+            <span className={modalFieldTitleClassName}>Pyth price feed id</span>
+            <span className={modalFieldDescriptionClassName}>
+              32-byte hex string (0x...).
+            </span>
+            <input
+              value={formState.pythPriceFeedIdHex}
+              onChange={(event) =>
+                handleInputChange("pythPriceFeedIdHex", event.target.value)
+              }
+              onBlur={() => markFieldBlur("pythPriceFeedIdHex")}
+              className={inputClassName(
+                shouldShowFieldError(
+                  "pythPriceFeedIdHex",
+                  fieldErrors.pythPriceFeedIdHex
+                )
+                  ? fieldErrors.pythPriceFeedIdHex
+                  : undefined
+              )}
+              placeholder="0x..."
+            />
+            {shouldShowFieldError(
+              "pythPriceFeedIdHex",
+              fieldErrors.pythPriceFeedIdHex
+            ) ? (
+              <span className={modalFieldErrorTextClassName}>
+                {fieldErrors.pythPriceFeedIdHex}
+              </span>
+            ) : undefined}
+          </label>
+        </ModalSection>
+      </ModalBody>
+
+      <div className="border-t border-slate-200/70 px-6 py-4 dark:border-slate-50/15">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="text-xs uppercase tracking-[0.18em] text-slate-500 dark:text-slate-200/60">
+            {transactionState.status === "processing"
+              ? "Waiting for wallet confirmation..."
+              : "Ready to update the AMM configuration."}
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button onClick={handleUpdateAmmConfig} disabled={!canSubmit}>
+              {transactionState.status === "processing"
+                ? "Processing..."
+                : "Update config"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </ModalFrame>
+  )
+}
+
+export default UpdateAmmConfigModal

--- a/packages/ui/src/app/helpers/ammAdminCap.ts
+++ b/packages/ui/src/app/helpers/ammAdminCap.ts
@@ -1,0 +1,24 @@
+import type { SuiClient } from "@mysten/sui/client"
+import { AMM_ADMIN_CAP_TYPE_SUFFIX } from "@sui-amm/domain-core/models/amm"
+import { getAllOwnedObjectsByFilter } from "@sui-amm/tooling-core/object"
+
+export const resolveAmmAdminCapId = async ({
+  ownerAddress,
+  packageId,
+  suiClient
+}: {
+  ownerAddress: string
+  packageId: string
+  suiClient: SuiClient
+}): Promise<string | undefined> => {
+  const adminCapType = `${packageId}${AMM_ADMIN_CAP_TYPE_SUFFIX}`
+  const adminCaps = await getAllOwnedObjectsByFilter(
+    {
+      ownerAddress,
+      filter: { StructType: adminCapType }
+    },
+    { suiClient }
+  )
+
+  return adminCaps[0]?.objectId
+}

--- a/packages/ui/src/app/hooks/useAmmConfigCardViewModel.ts
+++ b/packages/ui/src/app/hooks/useAmmConfigCardViewModel.ts
@@ -11,6 +11,7 @@ import type {
   TAmmConfigCardViewModel,
   TAmmConfigDetails
 } from "../types/TAmmConfigCard"
+import useAmmConfigUpdateEligibility from "./useAmmConfigUpdateEligibility"
 import useAmmConfigOverview, {
   type AmmConfigStatus
 } from "./useAmmConfigOverview"
@@ -108,8 +109,9 @@ const useAmmConfigCardViewModel = (): TAmmConfigCardState => {
   const { network: currentNetwork } = useSuiClientContext()
   const explorerUrl = useExplorerUrl()
   const ammConfigId = useResolvedAmmConfigId()
-  const { status, ammConfig, error, refreshAmmConfig } =
+  const { status, ammConfig, error, refreshAmmConfig, applyAmmConfigUpdate } =
     useAmmConfigOverview(ammConfigId)
+  const { canUpdateConfig } = useAmmConfigUpdateEligibility(ammConfigId)
 
   const networkLabel = useMemo(
     () => resolveNetworkLabel(currentNetwork),
@@ -139,7 +141,9 @@ const useAmmConfigCardViewModel = (): TAmmConfigCardState => {
   return {
     viewModel,
     ammConfig,
-    refreshAmmConfig
+    refreshAmmConfig,
+    canUpdateConfig,
+    applyAmmConfigUpdate
   }
 }
 

--- a/packages/ui/src/app/hooks/useAmmConfigUpdateEligibility.ts
+++ b/packages/ui/src/app/hooks/useAmmConfigUpdateEligibility.ts
@@ -1,0 +1,86 @@
+"use client"
+
+import { useCurrentAccount, useSuiClient } from "@mysten/dapp-kit"
+import type { SuiClient } from "@mysten/sui/client"
+import {
+  deriveRelevantPackageId,
+  getSuiObject
+} from "@sui-amm/tooling-core/object"
+import { useEffect, useState } from "react"
+import { resolveAmmAdminCapId } from "../helpers/ammAdminCap"
+
+type EligibilityState = {
+  status: "idle" | "loading" | "ready" | "error"
+  canUpdate: boolean
+}
+
+const emptyEligibilityState = (): EligibilityState => ({
+  status: "idle",
+  canUpdate: false
+})
+
+const fetchAmmPackageId = async ({
+  ammConfigId,
+  suiClient
+}: {
+  ammConfigId: string
+  suiClient: SuiClient
+}): Promise<string> => {
+  const { object } = await getSuiObject(
+    { objectId: ammConfigId },
+    { suiClient }
+  )
+  return deriveRelevantPackageId(object.type)
+}
+
+const useAmmConfigUpdateEligibility = (ammConfigId?: string) => {
+  const currentAccount = useCurrentAccount()
+  const suiClient = useSuiClient()
+  const walletAddress = currentAccount?.address
+  const [state, setState] = useState<EligibilityState>(emptyEligibilityState())
+
+  useEffect(() => {
+    let active = true
+
+    if (!walletAddress || !ammConfigId) {
+      setState(emptyEligibilityState())
+      return () => {
+        active = false
+      }
+    }
+
+    setState({ status: "loading", canUpdate: false })
+
+    const load = async () => {
+      try {
+        const packageId = await fetchAmmPackageId({ ammConfigId, suiClient })
+        const adminCapId = await resolveAmmAdminCapId({
+          ownerAddress: walletAddress,
+          packageId,
+          suiClient
+        })
+
+        if (!active) return
+        setState({
+          status: "ready",
+          canUpdate: Boolean(adminCapId)
+        })
+      } catch {
+        if (!active) return
+        setState({ status: "error", canUpdate: false })
+      }
+    }
+
+    void load()
+
+    return () => {
+      active = false
+    }
+  }, [ammConfigId, suiClient, walletAddress])
+
+  return {
+    canUpdateConfig: state.canUpdate
+  }
+}
+
+export default useAmmConfigUpdateEligibility

--- a/packages/ui/src/app/hooks/useUpdateAmmConfigModalState.ts
+++ b/packages/ui/src/app/hooks/useUpdateAmmConfigModalState.ts
@@ -1,0 +1,496 @@
+"use client"
+
+import {
+  useCurrentAccount,
+  useCurrentWallet,
+  useSignAndExecuteTransaction,
+  useSignTransaction,
+  useSuiClient,
+  useSuiClientContext
+} from "@mysten/dapp-kit"
+import type { SuiTransactionBlockResponse } from "@mysten/sui/client"
+import type { IdentifierString } from "@mysten/wallet-standard"
+import type { AmmConfigOverview } from "@sui-amm/domain-core/models/amm"
+import {
+  DEFAULT_BASE_SPREAD_BPS,
+  DEFAULT_VOLATILITY_MULTIPLIER_BPS,
+  getAmmConfigOverview,
+  resolveAmmConfigInputs
+} from "@sui-amm/domain-core/models/amm"
+import { buildUpdateAmmConfigTransaction } from "@sui-amm/domain-core/ptb/amm"
+import { deriveRelevantPackageId } from "@sui-amm/tooling-core/object"
+import { getSuiSharedObject } from "@sui-amm/tooling-core/shared-object"
+import { ENetwork } from "@sui-amm/tooling-core/types"
+import {
+  parseNonNegativeU64,
+  parsePositiveU64
+} from "@sui-amm/tooling-core/utils/utility"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { resolveAmmAdminCapId } from "../helpers/ammAdminCap"
+import {
+  resolveValidationMessage,
+  validateRequiredHexBytes
+} from "../helpers/inputValidation"
+import {
+  getLocalnetClient,
+  makeLocalnetExecutor,
+  walletSupportsChain
+} from "../helpers/localnet"
+import {
+  extractErrorDetails,
+  formatErrorMessage,
+  safeJsonStringify,
+  serializeForJson
+} from "../helpers/transactionErrors"
+import { waitForTransactionBlock } from "../helpers/transactionWait"
+import { useIdleFieldValidation } from "./useIdleFieldValidation"
+
+const PYTH_PRICE_FEED_ID_BYTES = 32
+
+type AmmUpdateFormState = {
+  baseSpreadBps: string
+  volatilityMultiplierBps: string
+  useLaser: boolean
+  tradingPaused: boolean
+  pythPriceFeedIdHex: string
+}
+
+type AmmUpdateFieldErrors = Partial<Record<keyof AmmUpdateFormState, string>>
+
+export type AmmConfigUpdateSummary = {
+  digest: string
+  transactionBlock: SuiTransactionBlockResponse
+  adminCapId: string
+  packageId: string
+  ammConfig: AmmConfigOverview
+}
+
+type TransactionState =
+  | { status: "idle" }
+  | { status: "processing" }
+  | { status: "success"; summary: AmmConfigUpdateSummary }
+  | { status: "error"; error: string; details?: string }
+
+const buildFormState = (ammConfig?: AmmConfigOverview): AmmUpdateFormState => ({
+  baseSpreadBps: ammConfig?.baseSpreadBps ?? DEFAULT_BASE_SPREAD_BPS,
+  volatilityMultiplierBps:
+    ammConfig?.volatilityMultiplierBps ?? DEFAULT_VOLATILITY_MULTIPLIER_BPS,
+  useLaser: ammConfig?.useLaser ?? false,
+  tradingPaused: ammConfig?.tradingPaused ?? false,
+  pythPriceFeedIdHex: ammConfig?.pythPriceFeedIdHex ?? ""
+})
+
+const buildFieldErrors = (
+  formState: AmmUpdateFormState
+): AmmUpdateFieldErrors => {
+  const errors: AmmUpdateFieldErrors = {}
+  const baseSpreadBps = formState.baseSpreadBps.trim()
+  const volatilityMultiplierBps = formState.volatilityMultiplierBps.trim()
+
+  if (!baseSpreadBps) {
+    errors.baseSpreadBps = "Base spread is required."
+  } else {
+    try {
+      parsePositiveU64(baseSpreadBps, "Base spread bps")
+    } catch (error) {
+      errors.baseSpreadBps = resolveValidationMessage(
+        error,
+        "Base spread must be a valid u64."
+      )
+    }
+  }
+
+  if (!volatilityMultiplierBps) {
+    errors.volatilityMultiplierBps = "Volatility multiplier is required."
+  } else {
+    try {
+      parseNonNegativeU64(volatilityMultiplierBps, "Volatility multiplier bps")
+    } catch (error) {
+      errors.volatilityMultiplierBps = resolveValidationMessage(
+        error,
+        "Volatility multiplier must be a valid u64."
+      )
+    }
+  }
+
+  const feedError = validateRequiredHexBytes({
+    value: formState.pythPriceFeedIdHex,
+    expectedBytes: PYTH_PRICE_FEED_ID_BYTES,
+    label: "Pyth price feed id"
+  })
+  if (feedError) errors.pythPriceFeedIdHex = feedError
+
+  return errors
+}
+
+const buildFallbackOverview = ({
+  configId,
+  formState,
+  baseSpreadBps,
+  volatilityMultiplierBps,
+  pythPriceFeedIdHex
+}: {
+  configId: string
+  formState: AmmUpdateFormState
+  baseSpreadBps: bigint
+  volatilityMultiplierBps: bigint
+  pythPriceFeedIdHex: string
+}): AmmConfigOverview => ({
+  configId,
+  baseSpreadBps: baseSpreadBps.toString(),
+  volatilityMultiplierBps: volatilityMultiplierBps.toString(),
+  useLaser: formState.useLaser,
+  tradingPaused: formState.tradingPaused,
+  pythPriceFeedIdHex
+})
+
+const ammConfigMatches = (
+  first: AmmConfigOverview,
+  second: AmmConfigOverview
+) =>
+  first.baseSpreadBps === second.baseSpreadBps &&
+  first.volatilityMultiplierBps === second.volatilityMultiplierBps &&
+  first.useLaser === second.useLaser &&
+  first.tradingPaused === second.tradingPaused &&
+  first.pythPriceFeedIdHex === second.pythPriceFeedIdHex
+
+export const useUpdateAmmConfigModalState = ({
+  open,
+  ammConfigId,
+  ammConfig,
+  onConfigUpdated
+}: {
+  open: boolean
+  ammConfigId?: string
+  ammConfig?: AmmConfigOverview
+  onConfigUpdated?: (config: AmmConfigOverview) => void
+}) => {
+  const currentAccount = useCurrentAccount()
+  const { currentWallet } = useCurrentWallet()
+  const suiClient = useSuiClient()
+  const { network } = useSuiClientContext()
+  const signAndExecuteTransaction = useSignAndExecuteTransaction()
+  const signTransaction = useSignTransaction()
+  const localnetClient = useMemo(() => getLocalnetClient(), [])
+  const isLocalnet = network === ENetwork.LOCALNET
+  const localnetExecutor = useMemo(
+    () =>
+      makeLocalnetExecutor({
+        client: localnetClient,
+        signTransaction: signTransaction.mutateAsync
+      }),
+    [localnetClient, signTransaction.mutateAsync]
+  )
+
+  const [formState, setFormState] = useState<AmmUpdateFormState>(() =>
+    buildFormState(ammConfig)
+  )
+  const [transactionState, setTransactionState] = useState<TransactionState>({
+    status: "idle"
+  })
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
+  const {
+    fieldDirty,
+    markFieldChange,
+    markFieldBlur,
+    resetFieldState,
+    shouldShowFieldFeedback
+  } = useIdleFieldValidation<keyof AmmUpdateFormState>({ idleDelayMs: 600 })
+
+  const walletAddress = currentAccount?.address
+
+  const fieldErrors = useMemo(() => buildFieldErrors(formState), [formState])
+  const hasFieldErrors = Object.values(fieldErrors).some(Boolean)
+  const hasDirtyFields = useMemo(
+    () => Object.values(fieldDirty).some(Boolean),
+    [fieldDirty]
+  )
+
+  const isSubmissionPending = isLocalnet
+    ? signTransaction.isPending
+    : signAndExecuteTransaction.isPending
+
+  const canSubmit =
+    Boolean(walletAddress && ammConfigId && !hasFieldErrors) &&
+    transactionState.status !== "processing" &&
+    isSubmissionPending !== true
+
+  const resetForm = useCallback(() => {
+    setFormState(buildFormState(ammConfig))
+    setTransactionState({ status: "idle" })
+    setHasAttemptedSubmit(false)
+    resetFieldState()
+  }, [ammConfig, resetFieldState])
+
+  useEffect(() => {
+    if (!open) return
+    setTransactionState({ status: "idle" })
+    setHasAttemptedSubmit(false)
+    resetFieldState()
+  }, [open, resetFieldState])
+
+  useEffect(() => {
+    if (!open) return
+    if (hasDirtyFields || hasAttemptedSubmit) return
+    setFormState(buildFormState(ammConfig))
+  }, [ammConfig, hasAttemptedSubmit, hasDirtyFields, open])
+
+  const handleInputChange = useCallback(
+    <K extends keyof AmmUpdateFormState>(
+      key: K,
+      value: AmmUpdateFormState[K]
+    ) => {
+      markFieldChange(key)
+      setFormState((previous) => ({
+        ...previous,
+        [key]: value
+      }))
+    },
+    [markFieldChange]
+  )
+
+  const shouldShowFieldError = useCallback(
+    <K extends keyof AmmUpdateFormState>(
+      key: K,
+      error?: string
+    ): error is string =>
+      Boolean(error && shouldShowFieldFeedback(key, hasAttemptedSubmit)),
+    [hasAttemptedSubmit, shouldShowFieldFeedback]
+  )
+
+  const handleUpdateAmmConfig = useCallback(async () => {
+    setHasAttemptedSubmit(true)
+
+    if (!walletAddress) {
+      setTransactionState({
+        status: "error",
+        error: "Connect a wallet to update the AMM configuration."
+      })
+      return
+    }
+
+    if (!ammConfigId) {
+      setTransactionState({
+        status: "error",
+        error: "AMM config ID is required to update configuration."
+      })
+      return
+    }
+
+    if (hasFieldErrors) return
+
+    const expectedChain = `sui:${network}` as IdentifierString
+    const accountChains = currentAccount?.chains ?? []
+    const localnetSupported = walletSupportsChain(
+      currentWallet ?? currentAccount ?? undefined,
+      expectedChain
+    )
+    const walletFeatureKeys = currentWallet
+      ? Object.keys(currentWallet.features)
+      : []
+    const chainMismatch =
+      accountChains.length > 0 && !accountChains.includes(expectedChain)
+
+    const walletContext = {
+      appNetwork: network,
+      expectedChain,
+      walletName: currentWallet?.name,
+      walletVersion: currentWallet?.version,
+      accountAddress: walletAddress,
+      accountChains,
+      chainMismatch,
+      localnetSupported,
+      walletFeatureKeys
+    }
+
+    if (!isLocalnet && chainMismatch) {
+      setTransactionState({
+        status: "error",
+        error: `Wallet chain mismatch. Switch your wallet to ${network}.`,
+        details: safeJsonStringify(
+          { walletContext, reason: "chain_mismatch" },
+          2
+        )
+      })
+      return
+    }
+
+    if (!currentWallet) {
+      setTransactionState({
+        status: "error",
+        error: "No wallet connected. Connect a wallet to continue.",
+        details: safeJsonStringify(
+          { walletContext, reason: "wallet_missing" },
+          2
+        )
+      })
+      return
+    }
+
+    setTransactionState({ status: "processing" })
+
+    let failureStage: "prepare" | "execute" | "fetch" | "refresh" = "prepare"
+
+    try {
+      const updateInputs = await resolveAmmConfigInputs({
+        baseSpreadBps: formState.baseSpreadBps.trim(),
+        volatilityMultiplierBps: formState.volatilityMultiplierBps.trim(),
+        useLaser: formState.useLaser,
+        pythPriceFeedIdHex: formState.pythPriceFeedIdHex.trim()
+      })
+
+      const configShared = await getSuiSharedObject(
+        { objectId: ammConfigId, mutable: true },
+        { suiClient }
+      )
+      const configId = configShared.object.objectId
+      const packageId = deriveRelevantPackageId(configShared.object.type)
+      const adminCapId = await resolveAmmAdminCapId({
+        ownerAddress: walletAddress,
+        packageId,
+        suiClient
+      })
+
+      if (!adminCapId)
+        throw new Error(
+          "No AMM admin capability found for the connected wallet."
+        )
+
+      const updateTransaction = buildUpdateAmmConfigTransaction({
+        packageId,
+        adminCapId,
+        config: configShared,
+        baseSpreadBps: updateInputs.baseSpreadBps,
+        volatilityMultiplierBps: updateInputs.volatilityMultiplierBps,
+        useLaser: updateInputs.useLaser,
+        tradingPaused: formState.tradingPaused,
+        pythPriceFeedIdBytes: updateInputs.pythPriceFeedIdBytes
+      })
+      updateTransaction.setSender(walletAddress)
+
+      let digest = ""
+      let transactionBlock: SuiTransactionBlockResponse
+
+      if (isLocalnet) {
+        failureStage = "execute"
+        const result = await localnetExecutor(updateTransaction, {
+          chain: expectedChain
+        })
+        digest = result.digest
+        transactionBlock = result
+      } else {
+        failureStage = "execute"
+        const result = await signAndExecuteTransaction.mutateAsync({
+          transaction: updateTransaction,
+          chain: expectedChain
+        })
+
+        failureStage = "fetch"
+        digest = result.digest
+        transactionBlock = await waitForTransactionBlock(suiClient, digest)
+      }
+
+      const optimisticOverview = buildFallbackOverview({
+        configId,
+        formState,
+        baseSpreadBps: updateInputs.baseSpreadBps,
+        volatilityMultiplierBps: updateInputs.volatilityMultiplierBps,
+        pythPriceFeedIdHex: updateInputs.pythPriceFeedIdHex
+      })
+
+      setTransactionState({
+        status: "success",
+        summary: {
+          digest,
+          transactionBlock,
+          adminCapId,
+          packageId,
+          ammConfig: optimisticOverview
+        }
+      })
+
+      onConfigUpdated?.(optimisticOverview)
+
+      try {
+        failureStage = "refresh"
+        const refreshedOverview = await getAmmConfigOverview(
+          configId,
+          suiClient
+        )
+        if (!ammConfigMatches(refreshedOverview, optimisticOverview)) return
+        setTransactionState({
+          status: "success",
+          summary: {
+            digest,
+            transactionBlock,
+            adminCapId,
+            packageId,
+            ammConfig: refreshedOverview
+          }
+        })
+        onConfigUpdated?.(refreshedOverview)
+      } catch {
+        // Keep optimistic summary when refresh fails or returns stale data.
+      }
+    } catch (error) {
+      const errorDetails = extractErrorDetails(error)
+      const localnetSupportNote =
+        isLocalnet && !localnetSupported && failureStage === "execute"
+          ? "Wallet may not support sui:localnet signing."
+          : undefined
+      const errorDetailsRaw = safeJsonStringify(
+        {
+          summary: errorDetails,
+          raw: serializeForJson(error),
+          failureStage,
+          localnetSupportNote,
+          walletContext
+        },
+        2
+      )
+      const formattedError = formatErrorMessage(error)
+      const errorMessage = localnetSupportNote
+        ? `${formattedError} ${localnetSupportNote}`
+        : formattedError
+      setTransactionState({
+        status: "error",
+        error: errorMessage,
+        details: errorDetailsRaw
+      })
+    }
+  }, [
+    ammConfigId,
+    currentAccount,
+    currentWallet,
+    formState,
+    hasFieldErrors,
+    isLocalnet,
+    localnetExecutor,
+    network,
+    onConfigUpdated,
+    signAndExecuteTransaction,
+    suiClient,
+    walletAddress
+  ])
+
+  const isSuccessState = transactionState.status === "success"
+  const isErrorState = transactionState.status === "error"
+  const transactionSummary = isSuccessState
+    ? transactionState.summary
+    : undefined
+
+  return {
+    formState,
+    fieldErrors,
+    transactionState,
+    transactionSummary,
+    isSuccessState,
+    isErrorState,
+    canSubmit,
+    handleInputChange,
+    markFieldBlur,
+    shouldShowFieldError,
+    handleUpdateAmmConfig,
+    resetForm
+  }
+}

--- a/packages/ui/src/app/types/TAmmConfigCard.ts
+++ b/packages/ui/src/app/types/TAmmConfigCard.ts
@@ -32,4 +32,6 @@ export type TAmmConfigCardState = {
   viewModel: TAmmConfigCardViewModel
   ammConfig?: AmmConfigOverview
   refreshAmmConfig: () => void
+  canUpdateConfig: boolean
+  applyAmmConfigUpdate: (ammConfig: AmmConfigOverview) => void
 }


### PR DESCRIPTION
Fixes #22
Fixes #40
Fixes #41

## Summary
Adds the admin-only AMM configuration panel for updating base spread and volatility-related config values.

## Scope
- Update modal component and transaction recap UX
- AdminCap eligibility checks
- Update form state, validation, transaction handling, and optimistic refresh
- Dashboard wiring for opening update flow and applying updated values

## Notes
This PR is stacked on top of the dashboard read-only PR.
