### PR TITLE
Expand CI workflow with Move tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 env:
   NODE_VERSION: "22.21.1"
   PNPM_VERSION: "10"
-  SUI_CLI_VERSION: "1.63.0"
+  SUI_CLI_VERSION: "1.63.1"
   CI: true
 
 jobs:
@@ -113,6 +113,22 @@ jobs:
             reports/**
             /tmp/sui-it-*/logs/**
           if-no-files-found: ignore
+
+  move-tests:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - prop-amm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/setup-sui
+      - name: Run Move tests (${{ matrix.package }})
+        run: sui move test --path ./packages/dapp/contracts/prop-amm --environment test-publish
 
   security-audit:
     if: github.event_name != 'pull_request'


### PR DESCRIPTION
Fixes #46

## Summary
Expands CI coverage with Move test execution and aligns workflow defaults with current package paths.

## Scope
- Add Move test job in CI matrix
- Update Sui CLI patch version in workflow env
- Ensure CI Move path points to `packages/dapp/contracts/prop-amm`
