### PR TITLE
Executor trader account creation and registration

### DIFF
--- a/packages/dapp/contracts/prop-amm/sources/executor.move
+++ b/packages/dapp/contracts/prop-amm/sources/executor.move
@@ -1,23 +1,66 @@
 /// Execution-time state and events for the AMM.
 module amm::executor;
 
-use sui::table::Table;
+use amm::manager;
+use deepbook::balance_manager::{Self, BalanceManager, DepositCap, TradeCap, WithdrawCap};
+use deepbook::registry::Registry;
+use sui::table::{Self, Table};
+
+// === Imports ===
+
+// === Errors ===
+
+const ENotTraderAccountOwner: u64 = 1;
+const EBalanceManagerMismatch: u64 = 2;
 
 // === Structs ===
+
+/// Application witness for DeepBook registry authorization.
+public struct PropAmmApp has drop {}
+
+/// Balance manager cap IDs owned by the trader account owner.
+public struct CapIds has copy, drop, store {
+    /// Trade capability ID.
+    trade_cap_id: Option<ID>,
+    /// Deposit capability ID.
+    deposit_cap_id: Option<ID>,
+    /// Withdraw capability ID.
+    withdraw_cap_id: Option<ID>,
+}
 
 /// Per-trader account state.
 ///
 /// Uses a table to map each pool ID to the trader's active order IDs.
-public struct TraderAccount has key {
+public struct TraderAccount has key, store {
     /// Unique ID for the account object.
     id: UID,
     /// Account owner.
     owner: address,
+    /// Balance manager ID for DeepBook trading.
+    balance_manager_id: ID,
+    /// Capability IDs retained by the owner.
+    cap_ids: CapIds,
     /// Active order IDs keyed by pool ID (table entries are stored on-chain).
     active_orders: Table<ID, vector<ID>>,
 }
 
 // === Events ===
+
+/// Emitted when a trader account is created.
+public struct TraderAccountCreatedEvent has copy, drop {
+    /// Trader account identifier.
+    trader_account_id: address,
+    /// Owner address.
+    owner: address,
+    /// Balance manager identifier.
+    balance_manager_id: ID,
+    /// Trade capability ID.
+    trade_cap_id: Option<ID>,
+    /// Deposit capability ID.
+    deposit_cap_id: Option<ID>,
+    /// Withdraw capability ID.
+    withdraw_cap_id: Option<ID>,
+}
 
 /// Emitted when a quote is updated.
 public struct QuoteUpdatedEvent has copy, drop {
@@ -37,4 +80,236 @@ public struct OrderExecutedEvent has copy, drop {
     order_id: ID,
     /// Execution price.
     fill_price: u64,
+}
+
+// === Public Functions ===
+
+/// Registers the balance manager in the DeepBook registry.
+///
+/// Only the trader account owner can call this entry.
+entry fun register_balance_manager(
+    trader_account: &TraderAccount,
+    balance_manager: &BalanceManager,
+    registry: &mut Registry,
+    ctx: &mut TxContext,
+) {
+    assert_trader_account_owner(trader_account, ctx);
+    assert_balance_manager_matches_account(trader_account, balance_manager);
+
+    balance_manager::register_balance_manager(balance_manager, registry, ctx);
+}
+
+/// Creates a balance manager with caps and a trader account, returning the objects for PTB composition.
+///
+/// Intended for callers that want to compose transfers/sharing in a larger PTB.
+/// Requires `PropAmmApp` to be authorized in the DeepBook registry.
+public fun create_trader_account_components(
+    deepbook_registry: &Registry,
+    owner: address,
+    ctx: &mut TxContext,
+): (BalanceManager, DepositCap, WithdrawCap, TradeCap, TraderAccount, CapIds) {
+    let (balance_manager, deposit_cap, withdraw_cap, trade_cap) = create_balance_manager_with_caps(
+        deepbook_registry,
+        owner,
+        ctx,
+    );
+
+    let (trader_account, cap_ids) = build_trader_account_with_cap_ids(
+        &balance_manager,
+        &trade_cap,
+        &deposit_cap,
+        &withdraw_cap,
+        owner,
+        ctx,
+    );
+
+    (balance_manager, deposit_cap, withdraw_cap, trade_cap, trader_account, cap_ids)
+}
+
+/// Creates a balance manager with caps and a trader account, transferring caps/account to the owner
+/// and sharing the balance manager.
+///
+/// Intended for the standard "one-step" flow (no custom PTB composition).
+/// Requires `PropAmmApp` to be authorized in the DeepBook registry.
+entry fun create_trader_account_with_shared_manager_and_owner_caps(
+    deepbook_registry: &Registry,
+    admin_cap: &manager::AMMAdminCap,
+    owner: address,
+    ctx: &mut TxContext,
+) {
+    manager::assert_admin_cap(admin_cap);
+
+    let (
+        balance_manager,
+        deposit_cap,
+        withdraw_cap,
+        trade_cap,
+        trader_account,
+        cap_ids,
+    ) = create_trader_account_components(deepbook_registry, owner, ctx);
+
+    let balance_manager_id = balance_manager::id(&balance_manager);
+    let trader_account_id = trader_account.id.to_address();
+
+    transfer::public_transfer(deposit_cap, owner);
+    transfer::public_transfer(withdraw_cap, owner);
+    transfer::public_transfer(trade_cap, owner);
+    transfer::public_transfer(trader_account, owner);
+    transfer::public_share_object(balance_manager);
+
+    emit_trader_account_created(
+        trader_account_id,
+        owner,
+        balance_manager_id,
+        &cap_ids,
+    );
+}
+
+// === Internal Helpers ===
+
+/// Ensures the transaction sender owns the trader account.
+fun assert_trader_account_owner(trader_account: &TraderAccount, ctx: &TxContext) {
+    assert!(ctx.sender() == trader_account.owner, ENotTraderAccountOwner);
+}
+
+/// Ensures the balance manager matches the trader account.
+fun assert_balance_manager_matches_account(
+    trader_account: &TraderAccount,
+    balance_manager: &BalanceManager,
+) {
+    assert!(
+        trader_account.balance_manager_id == balance_manager::id(balance_manager),
+        EBalanceManagerMismatch,
+    );
+}
+
+/// Creates a balance manager and mints caps for the owner.
+fun create_balance_manager_with_caps(
+    deepbook_registry: &Registry,
+    owner: address,
+    ctx: &mut TxContext,
+): (BalanceManager, DepositCap, WithdrawCap, TradeCap) {
+    balance_manager::new_with_custom_owner_caps<PropAmmApp>(
+        deepbook_registry,
+        owner,
+        ctx,
+    )
+}
+
+/// Builds a trader account and the associated cap ID metadata.
+fun build_trader_account_with_cap_ids(
+    balance_manager: &BalanceManager,
+    trade_cap: &TradeCap,
+    deposit_cap: &DepositCap,
+    withdraw_cap: &WithdrawCap,
+    owner: address,
+    ctx: &mut TxContext,
+): (TraderAccount, CapIds) {
+    let cap_ids = build_cap_ids(trade_cap, deposit_cap, withdraw_cap);
+    let trader_account = build_trader_account(
+        owner,
+        balance_manager::id(balance_manager),
+        copy cap_ids,
+        ctx,
+    );
+
+    (trader_account, cap_ids)
+}
+
+/// Captures the cap IDs for storage in the trader account.
+fun build_cap_ids(
+    trade_cap: &TradeCap,
+    deposit_cap: &DepositCap,
+    withdraw_cap: &WithdrawCap,
+): CapIds {
+    CapIds {
+        trade_cap_id: option::some(object::id(trade_cap)),
+        deposit_cap_id: option::some(object::id(deposit_cap)),
+        withdraw_cap_id: option::some(object::id(withdraw_cap)),
+    }
+}
+
+/// Constructs a trader account with empty active orders.
+fun build_trader_account(
+    owner: address,
+    balance_manager_id: ID,
+    cap_ids: CapIds,
+    ctx: &mut TxContext,
+): TraderAccount {
+    TraderAccount {
+        id: object::new(ctx),
+        owner,
+        balance_manager_id,
+        cap_ids,
+        active_orders: table::new(ctx),
+    }
+}
+
+/// Emits the trader account created event.
+fun emit_trader_account_created(
+    trader_account_id: address,
+    owner: address,
+    balance_manager_id: ID,
+    cap_ids: &CapIds,
+) {
+    sui::event::emit(TraderAccountCreatedEvent {
+        trader_account_id,
+        owner,
+        balance_manager_id,
+        trade_cap_id: cap_ids.trade_cap_id,
+        deposit_cap_id: cap_ids.deposit_cap_id,
+        withdraw_cap_id: cap_ids.withdraw_cap_id,
+    });
+}
+
+/// Emits a quote updated event for the given pool.
+public(package) fun emit_quote_updated(
+    pool_id: ID,
+    price: u64,
+    spread_bps: u64,
+    timestamp_ms: u64,
+) {
+    sui::event::emit(QuoteUpdatedEvent {
+        pool_id,
+        price,
+        spread_bps,
+        timestamp_ms,
+    });
+}
+
+/// Emits an order executed event.
+public(package) fun emit_order_executed(order_id: ID, fill_price: u64) {
+    sui::event::emit(OrderExecutedEvent { order_id, fill_price });
+}
+
+// === Test-Only Helpers ===
+
+#[test_only]
+/// Returns the trader account owner for tests.
+public fun owner(trader_account: &TraderAccount): address {
+    trader_account.owner
+}
+
+#[test_only]
+/// Returns the balance manager ID for tests.
+public fun balance_manager_id(trader_account: &TraderAccount): ID {
+    trader_account.balance_manager_id
+}
+
+#[test_only]
+/// Returns the trade cap ID for tests.
+public fun trade_cap_id(trader_account: &TraderAccount): Option<ID> {
+    trader_account.cap_ids.trade_cap_id
+}
+
+#[test_only]
+/// Returns the deposit cap ID for tests.
+public fun deposit_cap_id(trader_account: &TraderAccount): Option<ID> {
+    trader_account.cap_ids.deposit_cap_id
+}
+
+#[test_only]
+/// Returns the withdraw cap ID for tests.
+public fun withdraw_cap_id(trader_account: &TraderAccount): Option<ID> {
+    trader_account.cap_ids.withdraw_cap_id
 }

--- a/packages/dapp/contracts/prop-amm/tests/executor_tests.move
+++ b/packages/dapp/contracts/prop-amm/tests/executor_tests.move
@@ -1,0 +1,656 @@
+/// Tests for AMM executor behavior.
+#[test_only]
+module prop_amm::executor_tests;
+
+use deepbook::balance_manager;
+use deepbook::registry;
+use prop_amm::executor;
+use prop_amm::manager;
+use std::unit_test::{assert_eq, destroy};
+use sui::dynamic_field;
+use sui::test_scenario;
+use sui::vec_set;
+
+// === Imports ===
+
+// === Constants ===
+
+const ADMIN_ADDRESS: address = @0xA;
+const OWNER_ADDRESS: address = @0xB;
+const OTHER_ADDRESS: address = @0xC;
+
+// === Helpers ===
+
+/// Creates a registry and advances the scenario.
+fun create_registry_and_advance_scenario(
+    scenario: &mut test_scenario::Scenario,
+    sender: address,
+): ID {
+    let registry_id;
+    test_scenario::next_tx(scenario, sender);
+    {
+        registry_id = registry::test_registry(test_scenario::ctx(scenario));
+    };
+    registry_id
+}
+
+/// Authorizes the app and initializes the balance manager map.
+fun authorize_app_and_initialize_balance_manager_map(
+    scenario: &mut test_scenario::Scenario,
+    sender: address,
+    registry_id: ID,
+) {
+    test_scenario::next_tx(scenario, sender);
+    {
+        let mut registry = take_registry_from_scenario(scenario, registry_id);
+        let admin_cap = registry::get_admin_cap_for_testing(test_scenario::ctx(scenario));
+        registry::authorize_app<executor::PropAmmApp>(&mut registry, &admin_cap);
+        registry::init_balance_manager_map(
+            &mut registry,
+            &admin_cap,
+            test_scenario::ctx(scenario),
+        );
+        return_registry_to_scenario(registry);
+        destroy(admin_cap);
+    };
+}
+
+/// Authorizes the app without initializing the balance manager map.
+fun authorize_app_without_balance_manager_map(
+    scenario: &mut test_scenario::Scenario,
+    sender: address,
+    registry_id: ID,
+) {
+    test_scenario::next_tx(scenario, sender);
+    {
+        let mut registry = take_registry_from_scenario(scenario, registry_id);
+        let admin_cap = registry::get_admin_cap_for_testing(test_scenario::ctx(scenario));
+        registry::authorize_app<executor::PropAmmApp>(&mut registry, &admin_cap);
+        return_registry_to_scenario(registry);
+        destroy(admin_cap);
+    };
+}
+
+/// Initializes the manager and advances the scenario.
+fun init_manager_and_advance_scenario(scenario: &mut test_scenario::Scenario, sender: address) {
+    manager::init_for_testing(test_scenario::ctx(scenario));
+    test_scenario::next_tx(scenario, sender);
+    claim_admin_cap_from_store(scenario);
+    test_scenario::next_tx(scenario, sender);
+}
+
+/// Claims the admin cap from the shared store.
+fun claim_admin_cap_from_store(scenario: &mut test_scenario::Scenario) {
+    let mut store = test_scenario::take_shared<manager::AdminCapStore>(scenario);
+    manager::claim_admin_cap(&mut store, test_scenario::ctx(scenario));
+    test_scenario::return_shared(store);
+}
+
+/// Creates a trader account via entry and advances the scenario.
+fun create_trader_account_entry_and_advance_scenario(
+    scenario: &mut test_scenario::Scenario,
+    sender: address,
+    registry_id: ID,
+    owner: address,
+): test_scenario::TransactionEffects {
+    test_scenario::next_tx(scenario, sender);
+    {
+        let registry = take_registry_from_scenario(scenario, registry_id);
+        let admin_cap = take_admin_cap_from_scenario(scenario);
+        executor::create_trader_account_with_shared_manager_and_owner_caps(
+            &registry,
+            &admin_cap,
+            owner,
+            test_scenario::ctx(scenario),
+        );
+        return_registry_to_scenario(registry);
+        return_admin_cap_to_scenario(scenario, admin_cap);
+    };
+    test_scenario::next_tx(scenario, sender)
+}
+
+/// Takes the admin cap from the scenario.
+fun take_admin_cap_from_scenario(scenario: &test_scenario::Scenario): manager::AMMAdminCap {
+    test_scenario::take_from_sender<manager::AMMAdminCap>(scenario)
+}
+
+/// Returns the admin cap to the scenario.
+fun return_admin_cap_to_scenario(
+    scenario: &test_scenario::Scenario,
+    admin_cap: manager::AMMAdminCap,
+) {
+    test_scenario::return_to_sender(scenario, admin_cap);
+}
+
+/// Takes the registry from the scenario by ID.
+fun take_registry_from_scenario(
+    scenario: &test_scenario::Scenario,
+    registry_id: ID,
+): registry::Registry {
+    test_scenario::take_shared_by_id<registry::Registry>(scenario, registry_id)
+}
+
+/// Returns the registry to the scenario.
+fun return_registry_to_scenario(registry: registry::Registry) {
+    test_scenario::return_shared(registry);
+}
+
+/// Takes a shared balance manager from the scenario by ID.
+fun take_shared_balance_manager_from_scenario(
+    scenario: &test_scenario::Scenario,
+    balance_manager_id: ID,
+): balance_manager::BalanceManager {
+    test_scenario::take_shared_by_id<balance_manager::BalanceManager>(
+        scenario,
+        balance_manager_id,
+    )
+}
+
+/// Returns a shared balance manager to the scenario.
+fun return_shared_balance_manager_to_scenario(balance_manager: balance_manager::BalanceManager) {
+    test_scenario::return_shared(balance_manager);
+}
+
+/// Takes the trader account from the scenario.
+fun take_trader_account_from_scenario(scenario: &test_scenario::Scenario): executor::TraderAccount {
+    test_scenario::take_from_sender<executor::TraderAccount>(scenario)
+}
+
+/// Returns the trader account to the scenario.
+fun return_trader_account_to_scenario(
+    scenario: &test_scenario::Scenario,
+    trader_account: executor::TraderAccount,
+) {
+    test_scenario::return_to_sender(scenario, trader_account);
+}
+
+/// Takes the trade cap from the scenario.
+fun take_trade_cap_from_scenario(scenario: &test_scenario::Scenario): balance_manager::TradeCap {
+    test_scenario::take_from_sender<balance_manager::TradeCap>(scenario)
+}
+
+/// Takes the deposit cap from the scenario.
+fun take_deposit_cap_from_scenario(
+    scenario: &test_scenario::Scenario,
+): balance_manager::DepositCap {
+    test_scenario::take_from_sender<balance_manager::DepositCap>(scenario)
+}
+
+/// Takes the withdraw cap from the scenario.
+fun take_withdraw_cap_from_scenario(
+    scenario: &test_scenario::Scenario,
+): balance_manager::WithdrawCap {
+    test_scenario::take_from_sender<balance_manager::WithdrawCap>(scenario)
+}
+
+/// Returns all caps to the scenario.
+fun return_caps_to_scenario(
+    scenario: &test_scenario::Scenario,
+    deposit_cap: balance_manager::DepositCap,
+    withdraw_cap: balance_manager::WithdrawCap,
+    trade_cap: balance_manager::TradeCap,
+) {
+    test_scenario::return_to_sender(scenario, deposit_cap);
+    test_scenario::return_to_sender(scenario, withdraw_cap);
+    test_scenario::return_to_sender(scenario, trade_cap);
+}
+
+/// Asserts that a trader account matches the expected cap IDs.
+fun assert_trader_account_matches_caps(
+    trader_account: &executor::TraderAccount,
+    trade_cap_id: ID,
+    deposit_cap_id: ID,
+    withdraw_cap_id: ID,
+) {
+    assert_eq!(executor::trade_cap_id(trader_account), option::some(trade_cap_id));
+    assert_eq!(executor::deposit_cap_id(trader_account), option::some(deposit_cap_id));
+    assert_eq!(executor::withdraw_cap_id(trader_account), option::some(withdraw_cap_id));
+}
+
+// === Tests ===
+
+/// Creates trader account objects and validates ownership and cap IDs.
+#[test]
+fun create_trader_account_objects_happy_path() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+    authorize_app_and_initialize_balance_manager_map(
+        &mut scenario,
+        ADMIN_ADDRESS,
+        registry_id,
+    );
+
+    test_scenario::next_tx(&mut scenario, ADMIN_ADDRESS);
+    {
+        let registry = take_registry_from_scenario(&scenario, registry_id);
+        let (
+            balance_manager,
+            deposit_cap,
+            withdraw_cap,
+            trade_cap,
+            trader_account,
+            _,
+        ) = executor::create_trader_account_components(
+            &registry,
+            OWNER_ADDRESS,
+            test_scenario::ctx(&mut scenario),
+        );
+
+        assert_eq!(executor::owner(&trader_account), OWNER_ADDRESS);
+        let balance_manager_id = balance_manager::id(&balance_manager);
+        assert_eq!(executor::balance_manager_id(&trader_account), balance_manager_id);
+        assert_trader_account_matches_caps(
+            &trader_account,
+            object::id(&trade_cap),
+            object::id(&deposit_cap),
+            object::id(&withdraw_cap),
+        );
+
+        return_registry_to_scenario(registry);
+        transfer::public_share_object(balance_manager);
+        transfer::public_transfer(deposit_cap, OWNER_ADDRESS);
+        transfer::public_transfer(withdraw_cap, OWNER_ADDRESS);
+        transfer::public_transfer(trade_cap, OWNER_ADDRESS);
+        transfer::public_transfer(trader_account, OWNER_ADDRESS);
+    };
+
+    test_scenario::end(scenario);
+}
+
+/// Rejects trader account creation when the app is not authorized.
+#[test, expected_failure(abort_code = registry::EAppNotAuthorized)]
+fun create_trader_account_objects_rejects_unauthorized_app() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+
+    test_scenario::next_tx(&mut scenario, ADMIN_ADDRESS);
+    {
+        let registry = take_registry_from_scenario(&scenario, registry_id);
+        let (
+            balance_manager,
+            deposit_cap,
+            withdraw_cap,
+            trade_cap,
+            trader_account,
+            _,
+        ) = executor::create_trader_account_components(
+            &registry,
+            OWNER_ADDRESS,
+            test_scenario::ctx(&mut scenario),
+        );
+
+        transfer::public_share_object(balance_manager);
+        return_caps_to_scenario(&scenario, deposit_cap, withdraw_cap, trade_cap);
+        return_trader_account_to_scenario(&scenario, trader_account);
+    };
+    abort
+}
+
+/// Creates a trader account via entry and verifies owned objects.
+#[test]
+fun create_trader_account_entry_happy_path() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+    authorize_app_and_initialize_balance_manager_map(
+        &mut scenario,
+        ADMIN_ADDRESS,
+        registry_id,
+    );
+    init_manager_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+
+    test_scenario::next_tx(&mut scenario, ADMIN_ADDRESS);
+    {
+        let registry = take_registry_from_scenario(&scenario, registry_id);
+        let admin_cap = take_admin_cap_from_scenario(&scenario);
+        executor::create_trader_account_with_shared_manager_and_owner_caps(
+            &registry,
+            &admin_cap,
+            OWNER_ADDRESS,
+            test_scenario::ctx(&mut scenario),
+        );
+        return_registry_to_scenario(registry);
+        return_admin_cap_to_scenario(&scenario, admin_cap);
+    };
+
+    test_scenario::next_tx(&mut scenario, OWNER_ADDRESS);
+    {
+        let trader_account = take_trader_account_from_scenario(&scenario);
+        let trade_cap = take_trade_cap_from_scenario(&scenario);
+        let deposit_cap = take_deposit_cap_from_scenario(&scenario);
+        let withdraw_cap = take_withdraw_cap_from_scenario(&scenario);
+        let balance_manager_id = executor::balance_manager_id(
+            &trader_account,
+        );
+        let balance_manager = take_shared_balance_manager_from_scenario(
+            &scenario,
+            balance_manager_id,
+        );
+
+        assert_trader_account_matches_caps(
+            &trader_account,
+            object::id(&trade_cap),
+            object::id(&deposit_cap),
+            object::id(&withdraw_cap),
+        );
+
+        return_shared_balance_manager_to_scenario(balance_manager);
+        return_caps_to_scenario(&scenario, deposit_cap, withdraw_cap, trade_cap);
+        return_trader_account_to_scenario(&scenario, trader_account);
+    };
+
+    test_scenario::end(scenario);
+}
+
+/// Emits an event when a trader account is created.
+#[test]
+fun create_trader_account_entry_emits_event() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+    authorize_app_and_initialize_balance_manager_map(
+        &mut scenario,
+        ADMIN_ADDRESS,
+        registry_id,
+    );
+    init_manager_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+
+    let effects = create_trader_account_entry_and_advance_scenario(
+        &mut scenario,
+        ADMIN_ADDRESS,
+        registry_id,
+        OWNER_ADDRESS,
+    );
+
+    assert_eq!(test_scenario::num_user_events(&effects), 2);
+
+    test_scenario::end(scenario);
+}
+
+/// Rejects entry creation when the app is not authorized.
+#[test, expected_failure(abort_code = registry::EAppNotAuthorized)]
+fun create_trader_account_entry_rejects_unauthorized_app() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+    init_manager_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+
+    test_scenario::next_tx(&mut scenario, ADMIN_ADDRESS);
+    {
+        let registry = take_registry_from_scenario(&scenario, registry_id);
+        let admin_cap = take_admin_cap_from_scenario(&scenario);
+        executor::create_trader_account_with_shared_manager_and_owner_caps(
+            &registry,
+            &admin_cap,
+            OWNER_ADDRESS,
+            test_scenario::ctx(&mut scenario),
+        );
+    };
+    abort
+}
+
+/// Registers the balance manager and verifies registry membership.
+#[test]
+fun register_balance_manager_happy_path() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+    authorize_app_and_initialize_balance_manager_map(
+        &mut scenario,
+        ADMIN_ADDRESS,
+        registry_id,
+    );
+    init_manager_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+
+    test_scenario::next_tx(&mut scenario, ADMIN_ADDRESS);
+    {
+        let registry = take_registry_from_scenario(&scenario, registry_id);
+        let admin_cap = take_admin_cap_from_scenario(&scenario);
+        executor::create_trader_account_with_shared_manager_and_owner_caps(
+            &registry,
+            &admin_cap,
+            OWNER_ADDRESS,
+            test_scenario::ctx(&mut scenario),
+        );
+        return_registry_to_scenario(registry);
+        return_admin_cap_to_scenario(&scenario, admin_cap);
+    };
+
+    test_scenario::next_tx(&mut scenario, OWNER_ADDRESS);
+    {
+        let mut registry = take_registry_from_scenario(&scenario, registry_id);
+        let trader_account = take_trader_account_from_scenario(&scenario);
+        let balance_manager_id = executor::balance_manager_id(
+            &trader_account,
+        );
+        let balance_manager = take_shared_balance_manager_from_scenario(
+            &scenario,
+            balance_manager_id,
+        );
+
+        executor::register_balance_manager(
+            &trader_account,
+            &balance_manager,
+            &mut registry,
+            test_scenario::ctx(&mut scenario),
+        );
+        let balance_manager_ids = registry::get_balance_manager_ids(
+            &registry,
+            OWNER_ADDRESS,
+        );
+        assert_eq!(vec_set::contains(&balance_manager_ids, &balance_manager_id), true);
+
+        return_registry_to_scenario(registry);
+        return_shared_balance_manager_to_scenario(balance_manager);
+        return_trader_account_to_scenario(&scenario, trader_account);
+    };
+
+    test_scenario::end(scenario);
+}
+
+/// Re-registering the same balance manager keeps the registry idempotent.
+#[test]
+fun register_balance_manager_is_idempotent() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+    authorize_app_and_initialize_balance_manager_map(
+        &mut scenario,
+        ADMIN_ADDRESS,
+        registry_id,
+    );
+    init_manager_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+
+    test_scenario::next_tx(&mut scenario, ADMIN_ADDRESS);
+    {
+        let registry = take_registry_from_scenario(&scenario, registry_id);
+        let admin_cap = take_admin_cap_from_scenario(&scenario);
+        executor::create_trader_account_with_shared_manager_and_owner_caps(
+            &registry,
+            &admin_cap,
+            OWNER_ADDRESS,
+            test_scenario::ctx(&mut scenario),
+        );
+        return_registry_to_scenario(registry);
+        return_admin_cap_to_scenario(&scenario, admin_cap);
+    };
+
+    test_scenario::next_tx(&mut scenario, OWNER_ADDRESS);
+    {
+        let mut registry = take_registry_from_scenario(&scenario, registry_id);
+        let trader_account = take_trader_account_from_scenario(&scenario);
+        let balance_manager_id = executor::balance_manager_id(
+            &trader_account,
+        );
+        let balance_manager = take_shared_balance_manager_from_scenario(
+            &scenario,
+            balance_manager_id,
+        );
+
+        executor::register_balance_manager(
+            &trader_account,
+            &balance_manager,
+            &mut registry,
+            test_scenario::ctx(&mut scenario),
+        );
+        executor::register_balance_manager(
+            &trader_account,
+            &balance_manager,
+            &mut registry,
+            test_scenario::ctx(&mut scenario),
+        );
+
+        let balance_manager_ids = registry::get_balance_manager_ids(
+            &registry,
+            OWNER_ADDRESS,
+        );
+        assert_eq!(vec_set::length(&balance_manager_ids), 1);
+        assert_eq!(vec_set::contains(&balance_manager_ids, &balance_manager_id), true);
+
+        return_registry_to_scenario(registry);
+        return_shared_balance_manager_to_scenario(balance_manager);
+        return_trader_account_to_scenario(&scenario, trader_account);
+    };
+
+    test_scenario::end(scenario);
+}
+
+/// Rejects registering when the balance manager map is missing.
+#[test, expected_failure(abort_code = dynamic_field::EFieldDoesNotExist)]
+fun register_balance_manager_rejects_missing_balance_manager_map() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+    authorize_app_without_balance_manager_map(
+        &mut scenario,
+        ADMIN_ADDRESS,
+        registry_id,
+    );
+    init_manager_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+
+    test_scenario::next_tx(&mut scenario, ADMIN_ADDRESS);
+    {
+        let registry = take_registry_from_scenario(&scenario, registry_id);
+        let admin_cap = take_admin_cap_from_scenario(&scenario);
+        executor::create_trader_account_with_shared_manager_and_owner_caps(
+            &registry,
+            &admin_cap,
+            OWNER_ADDRESS,
+            test_scenario::ctx(&mut scenario),
+        );
+        return_registry_to_scenario(registry);
+        return_admin_cap_to_scenario(&scenario, admin_cap);
+    };
+
+    test_scenario::next_tx(&mut scenario, OWNER_ADDRESS);
+    {
+        let mut registry = take_registry_from_scenario(&scenario, registry_id);
+        let trader_account = take_trader_account_from_scenario(&scenario);
+        let balance_manager_id = executor::balance_manager_id(
+            &trader_account,
+        );
+        let balance_manager = take_shared_balance_manager_from_scenario(
+            &scenario,
+            balance_manager_id,
+        );
+        executor::register_balance_manager(
+            &trader_account,
+            &balance_manager,
+            &mut registry,
+            test_scenario::ctx(&mut scenario),
+        );
+    };
+    abort
+}
+
+/// Rejects registering when the caller is not the owner.
+#[test, expected_failure(abort_code = executor::ENotTraderAccountOwner)]
+fun register_balance_manager_rejects_non_owner() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+    authorize_app_and_initialize_balance_manager_map(
+        &mut scenario,
+        ADMIN_ADDRESS,
+        registry_id,
+    );
+    init_manager_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+
+    test_scenario::next_tx(&mut scenario, ADMIN_ADDRESS);
+    {
+        let registry = take_registry_from_scenario(&scenario, registry_id);
+        let admin_cap = take_admin_cap_from_scenario(&scenario);
+        executor::create_trader_account_with_shared_manager_and_owner_caps(
+            &registry,
+            &admin_cap,
+            OWNER_ADDRESS,
+            test_scenario::ctx(&mut scenario),
+        );
+        return_registry_to_scenario(registry);
+        return_admin_cap_to_scenario(&scenario, admin_cap);
+    };
+
+    test_scenario::next_tx(&mut scenario, OWNER_ADDRESS);
+    {
+        let trader_account = take_trader_account_from_scenario(&scenario);
+        transfer::public_transfer(trader_account, OTHER_ADDRESS);
+    };
+
+    test_scenario::next_tx(&mut scenario, OTHER_ADDRESS);
+    {
+        let mut registry = take_registry_from_scenario(&scenario, registry_id);
+        let trader_account = take_trader_account_from_scenario(&scenario);
+        let balance_manager_id = executor::balance_manager_id(
+            &trader_account,
+        );
+        let balance_manager = take_shared_balance_manager_from_scenario(
+            &scenario,
+            balance_manager_id,
+        );
+
+        executor::register_balance_manager(
+            &trader_account,
+            &balance_manager,
+            &mut registry,
+            test_scenario::ctx(&mut scenario),
+        );
+    };
+    abort
+}
+
+/// Rejects registering when the balance manager does not match the account.
+#[test, expected_failure(abort_code = executor::EBalanceManagerMismatch)]
+fun register_balance_manager_rejects_mismatched_balance_manager() {
+    let mut scenario = test_scenario::begin(ADMIN_ADDRESS);
+    let registry_id = create_registry_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+    authorize_app_and_initialize_balance_manager_map(
+        &mut scenario,
+        ADMIN_ADDRESS,
+        registry_id,
+    );
+    init_manager_and_advance_scenario(&mut scenario, ADMIN_ADDRESS);
+
+    test_scenario::next_tx(&mut scenario, ADMIN_ADDRESS);
+    {
+        let registry = take_registry_from_scenario(&scenario, registry_id);
+        let admin_cap = take_admin_cap_from_scenario(&scenario);
+        executor::create_trader_account_with_shared_manager_and_owner_caps(
+            &registry,
+            &admin_cap,
+            OWNER_ADDRESS,
+            test_scenario::ctx(&mut scenario),
+        );
+        return_registry_to_scenario(registry);
+        return_admin_cap_to_scenario(&scenario, admin_cap);
+    };
+
+    test_scenario::next_tx(&mut scenario, OWNER_ADDRESS);
+    {
+        let mut registry = take_registry_from_scenario(&scenario, registry_id);
+        let trader_account = take_trader_account_from_scenario(&scenario);
+        let other_balance_manager = balance_manager::new(
+            test_scenario::ctx(&mut scenario),
+        );
+
+        executor::register_balance_manager(
+            &trader_account,
+            &other_balance_manager,
+            &mut registry,
+            test_scenario::ctx(&mut scenario),
+        );
+    };
+    abort
+}


### PR DESCRIPTION
## Split Context
This pull request is split from #47.

## Stack Dependency
Depends on #72.

## Scope
- Implement trader-account creation and balance-manager registration in `executor`.
- Add Move tests for authorization, ownership, and mismatch paths.

## Related Issues
- #16
- #27
