### PR TITLE
ref: apply Move Code Quality Checklist

### DIFF
--- a/packages/dapp/contracts/prop-amm/sources/config.move
+++ b/packages/dapp/contracts/prop-amm/sources/config.move
@@ -94,7 +94,7 @@ public fun create<BaseAsset, QuoteAsset>(
     }
 }
 
-// === View Functions ===
+// === View helpers ===
 
 /// Returns the base spread in basis points.
 public fun base_spread_bps(config: &AMMConfig): u64 {

--- a/packages/dapp/contracts/prop-amm/sources/events.move
+++ b/packages/dapp/contracts/prop-amm/sources/events.move
@@ -3,6 +3,8 @@ module openzeppelin_market_maker::events;
 
 use sui::event;
 
+// === Events ===
+
 /// Emitted when a market maker is created.
 public struct MarketMakerCreated has copy, drop {
     /// ID of the market maker object.
@@ -39,6 +41,8 @@ public struct MarketMakerConfigUpdated has copy, drop {
     market_maker_id: ID,
 }
 
+// === Package Functions ===
+
 /// Emit a `MarketMakerCreated` event.
 public(package) fun emit_market_maker_created(market_maker_id: ID) {
     event::emit(MarketMakerCreated { market_maker_id });
@@ -68,7 +72,7 @@ public(package) fun emit_market_maker_config_updated(market_maker_id: ID) {
     event::emit(MarketMakerConfigUpdated { market_maker_id });
 }
 
-// === Test only helpers ===
+// === Test-Only Helpers ===
 
 /// Builds a `MarketMakerCreated` payload.
 #[test_only]

--- a/packages/dapp/contracts/prop-amm/sources/executor.move
+++ b/packages/dapp/contracts/prop-amm/sources/executor.move
@@ -28,7 +28,7 @@ const EPythPriceNonPositive: vector<u8> = "pyth price must be positive";
 #[error(code = 1)]
 const EPythExponentNonNegative: vector<u8> = "pyth price exponent_u128 must be negative";
 #[error(code = 2)]
-const ExponentTooLarge: vector<u8> = "price exponent too large";
+const EExponentTooLarge: vector<u8> = "price exponent too large";
 #[error(code = 3)]
 const EPythInvalidPriceValue: vector<u8> = "pyth price must be of valid size";
 #[error(code = 4)]
@@ -87,10 +87,10 @@ public struct Caps has store {
     withdraw_cap: WithdrawCap,
 }
 
-// === Init ===
-
 /// One-time publisher witness created at publish time.
 public struct EXECUTOR has drop {}
+
+// === Init ===
 
 /// Initializes publish-time metadata by claiming and keeping the package publisher object.
 fun init(publisher_witness: EXECUTOR, ctx: &mut TxContext) {
@@ -271,7 +271,7 @@ public fun refresh_quotes<BaseAsset, QuoteAsset>(
     // Protects from calling permissionless quote refresh with old pricing,
     // that will force market maker resubmit orders and loose priority.
     let is_price_stale =
-        market_maker.is_base_price_stale(base_pyth_price) 
+        market_maker.is_base_price_stale(base_pyth_price)
         && market_maker.is_quote_price_stale(quote_pyth_price);
     if (is_price_stale) {
         return
@@ -387,7 +387,7 @@ public fun refresh_quotes<BaseAsset, QuoteAsset>(
     );
 }
 
-// === View Functions ===
+// === View helpers ===
 
 /// Returns the market maker ID.
 public fun id(market_maker: &MarketMaker): ID {
@@ -561,8 +561,8 @@ fun deepbook_usd_price(price: Price, max_conf_ratio_bps: u64): (u128, u8) {
     let exponent = expo_i64
         .get_magnitude_if_negative()
         .try_as_u8()
-        .destroy_or!(abort ExponentTooLarge);
-    assert!(exponent <= MAX_DECIMAL_POWER, ExponentTooLarge);
+        .destroy_or!(abort EExponentTooLarge);
+    assert!(exponent <= MAX_DECIMAL_POWER, EExponentTooLarge);
 
     (mantissa, exponent)
 }
@@ -575,8 +575,8 @@ fun deepbook_price(
     quote_decimals: u8,
     max_conf_ratio_bps: u64,
 ): u64 {
-    assert!(base_decimals <= MAX_DECIMAL_POWER, ExponentTooLarge);
-    assert!(quote_decimals <= MAX_DECIMAL_POWER, ExponentTooLarge);
+    assert!(base_decimals <= MAX_DECIMAL_POWER, EExponentTooLarge);
+    assert!(quote_decimals <= MAX_DECIMAL_POWER, EExponentTooLarge);
 
     let (base_mantissa, base_exponent) = deepbook_usd_price(base_price, max_conf_ratio_bps);
     let (quote_mantissa, quote_exponent) = deepbook_usd_price(quote_price, max_conf_ratio_bps);
@@ -616,8 +616,8 @@ fun quote_to_base_quantity(quote_quantity: u64, deepbook_price: u64): u64 {
 
 // === Test-Only Helpers ===
 
-#[test_only]
 /// Creates the package witness and runs init for tests.
+#[test_only]
 public fun test_init(ctx: &mut TxContext) {
     let publisher_witness = sui::test_utils::create_one_time_witness<EXECUTOR>();
     init(

--- a/packages/dapp/contracts/prop-amm/tests/config_tests.move
+++ b/packages/dapp/contracts/prop-amm/tests/config_tests.move
@@ -15,6 +15,8 @@ use std::unit_test::assert_eq;
 use sui::sui::SUI;
 use sui::test_scenario;
 
+// === Test-Only Helpers ===
+
 fun create_registry_and_pool(scenario: &mut test_scenario::Scenario, sender: address): ID {
     scenario.next_tx(sender);
     registry::test_registry(scenario.ctx());

--- a/packages/dapp/contracts/prop-amm/tests/executor_tests.move
+++ b/packages/dapp/contracts/prop-amm/tests/executor_tests.move
@@ -34,6 +34,8 @@ use sui::event;
 use sui::sui::SUI;
 use sui::test_scenario;
 
+// === Test-Only Helpers ===
+
 fun create_registry(scenario: &mut test_scenario::Scenario, sender: address) {
     scenario.next_tx(sender);
     registry::test_registry(scenario.ctx());

--- a/packages/dapp/contracts/prop-amm/tests/test_helpers.move
+++ b/packages/dapp/contracts/prop-amm/tests/test_helpers.move
@@ -1,3 +1,4 @@
+/// Shared test helpers for the AMM package tests.
 #[test_only]
 module openzeppelin_market_maker::test_helpers;
 
@@ -10,6 +11,8 @@ use sui::coin_registry::{Self, Currency};
 use sui::sui::SUI;
 use sui::test_scenario;
 
+// === Structs ===
+
 /// Test-only USDC type for DeepBook pool quote asset.
 public struct USDC has key {
     id: UID,
@@ -19,6 +22,8 @@ public struct USDC has key {
 public struct USDT has key {
     id: UID,
 }
+
+// === Test-Only Helpers ===
 
 /// Creates a `Currency<USDC>` for testing via `coin_registry`.
 /// Uses `tx_context::dummy()` to get a context with sender `@0x0` (required by coin_registry).


### PR DESCRIPTION
## Summary

Applies the `/move-quality` checklist to `prop-amm` source and test files.

- Rename error constant `ExponentTooLarge` → `EExponentTooLarge` (EPascalCase)
- Move `EXECUTOR` witness struct from `Init` to `Structs` section
- Normalise section headers: `View Functions` → `View helpers`, `Test only helpers` → `Test-Only Helpers`
- Add missing `Events` / `Package Functions` / `Test-Only Helpers` section headers
- Add module-level doc comment to `test_helpers`
- Reorder `#[test_only]` attribute after `///` doc comment on `test_init`

Prettier, `sui move build --lint --warnings-are-errors` (normal + `--test`), and `sui move test` (21/21) all pass.