### PR TITLE
fix(L-01): Quote Refresh Reverts on Non-Whitelisted DeepBook Pools

### DIFF
--- a/packages/dapp/contracts/coin-mock/Move.toml
+++ b/packages/dapp/contracts/coin-mock/Move.toml
@@ -3,5 +3,5 @@ name = "local_mock_coin"
 edition = "2024"
 
 [environments]
-test-publish = "1e949fe3"
+test-publish = "46b6270d"
 localnet = "305e72d1"

--- a/packages/dapp/contracts/prop-amm/Move.lock
+++ b/packages/dapp/contracts/prop-amm/Move.lock
@@ -39,3 +39,57 @@ source = { local = "../../../../vendor/deepbookv3/packages/token" }
 use_environment = "test-publish"
 manifest_digest = "2963D6B4689ED068546E86F8453FBCA51DCDF68A1C96D681328D2CDACE14B5CF"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.MoveStdlib_1]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "041c5f2bae2fe52079e44b70514333532d69f4e6" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Pyth]
+source = { git = "https://github.com/pyth-network/pyth-crosschain.git", subdir = "target_chains/sui/contracts", rev = "62c7a5bc0fc857ba6417ad780190552d4919ceca" }
+use_environment = "testnet"
+manifest_digest = "EE442EEB0E1F71B244DBB1E016B1D0D8F67061BDAFA606B6C86F093D15CA0755"
+deps = { Sui = "Sui_1", Wormhole = "Wormhole" }
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.Sui_1]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "041c5f2bae2fe52079e44b70514333532d69f4e6" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib_1" }
+
+[pinned.testnet.Wormhole]
+source = { git = "https://github.com/wormhole-foundation/wormhole.git", subdir = "sui/wormhole", rev = "1b1cb69e809e0e7081cf1bf9b2779c41c14fc7f0" }
+use_environment = "testnet"
+manifest_digest = "6996F1AB8CD448FFBA142C085C488FE8A46B485E61E38A1891EFA52B30D9C12E"
+deps = { Sui = "Sui_1" }
+
+[pinned.testnet.deepbook]
+source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/deepbook", rev = "b0c3f8b42f5209205dc3f2802b9312e59518a692" }
+use_environment = "testnet"
+manifest_digest = "3101923B9428545A4F52FFAD1C4F959F9BFFF84CD09CE4BCC1CB831286999B5A"
+deps = { std = "MoveStdlib", sui = "Sui", token = "token" }
+
+[pinned.testnet.openzeppelin_market_maker]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "D898E3EAE56DD0D14D7C8DA5C29EC4EA9D9FEE5E710C406A485AD8A0DF2F7645"
+deps = { deepbook = "deepbook", pyth = "Pyth", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token]
+source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "f0e476420c38ec92cd8610b82edfe67ec03e8232" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/packages/dapp/contracts/prop-amm/Move.toml
+++ b/packages/dapp/contracts/prop-amm/Move.toml
@@ -24,6 +24,6 @@ override = true
 addr_substitutions = { pyth = "0x2" }
 
 [environments]
-test-publish = "1e949fe3"
+test-publish = "46b6270d"
 [dep-replacements.test-publish]
 deepbook = { local = "../../../../vendor/deepbookv3/packages/deepbook", override = true }

--- a/packages/dapp/contracts/prop-amm/README.md
+++ b/packages/dapp/contracts/prop-amm/README.md
@@ -12,6 +12,10 @@ It is experimental and unaudited.
 - Two quote refresh entrypoints: `refresh_quotes_permissionless` (bot-driven, reads Pyth) and `refresh_quotes` (admin-driven, accepts an off-chain mid price). Both compute spreads and place limit orders.
 - Event surface for market maker executor creation and quote updates (`events.move`).
 
+## Pool requirements
+
+Only **whitelisted** DeepBook pools (`pool.whitelisted() == true`) are supported. The quote-refresh ladder allocates 100% of each side's settled balance across two limit orders with no fee headroom, and orders are placed with `pay_with_deep = false`. On non-whitelisted pools DeepBook charges the maker fee in the input asset, so the second order on each side aborts the refresh with `EBalanceManagerBalanceTooLow`. `market::new` rejects non-whitelisted pools at construction time with `EPoolNotWhitelisted`.
+
 ## Modules
 
 - `market`: validates and builds `Market` values (pool ID, per-side coin type / decimals / Pyth feed ID / cached publish timestamp).

--- a/packages/dapp/contracts/prop-amm/sources/market.move
+++ b/packages/dapp/contracts/prop-amm/sources/market.move
@@ -26,6 +26,8 @@ const EPythPriceConfidenceTooWide: vector<u8> = "pyth price confidence interval 
 const EPriceUnderflow: vector<u8> = "price lower than minimum or underflowed";
 #[error(code = 7)]
 const EPriceOverflow: vector<u8> = "price higher than maximum or overflowed";
+#[error(code = 8)]
+const EPoolNotWhitelisted: vector<u8> = "deepbook pool must be whitelisted";
 
 // === Constants ===
 
@@ -68,6 +70,9 @@ public struct MarketCurrency has drop, store {
 /// generically typed; the returned struct carries only the derived `pool_id`, the cached
 /// decimals, and the Pyth feed identifiers, so downstream executor state stays non-generic.
 ///
+/// `pool` must be a whitelisted DeepBook pool (`pool.whitelisted() == true`). On
+/// non-whitelisted pools, DeepBook charges a maker fee in the input asset when
+/// `pay_with_deep = false`.
 /// Pass the returned value into `executor::create` when creating a new market maker executor.
 public fun new<BaseAsset, QuoteAsset>(
     pool: &Pool<BaseAsset, QuoteAsset>,
@@ -76,6 +81,7 @@ public fun new<BaseAsset, QuoteAsset>(
     base_pyth_price_feed_id: vector<u8>,
     quote_pyth_price_feed_id: vector<u8>,
 ): Market {
+    assert!(pool.whitelisted(), EPoolNotWhitelisted);
     assert!(
         base_pyth_price_feed_id.length() == PYTH_PRICE_IDENTIFIER_LENGTH,
         EInvalidPythPriceFeedIdLength,

--- a/packages/dapp/contracts/prop-amm/tests/market_tests.move
+++ b/packages/dapp/contracts/prop-amm/tests/market_tests.move
@@ -9,6 +9,7 @@ use openzeppelin_market_maker::test_helpers::{
     USDC,
     build_invalid_pyth_price_feed_id,
     build_pyth_price_feed_id,
+    create_non_whitelisted_pool,
     create_pool,
     create_sui_currency,
     create_usdc_currency
@@ -102,6 +103,31 @@ fun create_market_rejects_invalid_base_feed_id_length() {
         &sui_currency,
         &usdc_currency,
         build_invalid_pyth_price_feed_id(),
+        build_pyth_price_feed_id(1),
+    );
+
+    abort
+}
+
+#[test, expected_failure(abort_code = market::EPoolNotWhitelisted)]
+fun create_market_rejects_non_whitelisted_pool() {
+    let sender = @0xE;
+    let mut scenario = test_scenario::begin(sender);
+    scenario.next_tx(sender);
+    registry::test_registry(scenario.ctx());
+    let pool_id = create_non_whitelisted_pool(&mut scenario, sender);
+
+    scenario.next_tx(sender);
+
+    let pool: Pool<SUI, USDC> = scenario.take_shared_by_id(pool_id);
+    let sui_currency = create_sui_currency();
+    let usdc_currency = create_usdc_currency();
+
+    let _market = market::new(
+        &pool,
+        &sui_currency,
+        &usdc_currency,
+        build_pyth_price_feed_id(0),
         build_pyth_price_feed_id(1),
     );
 

--- a/packages/dapp/contracts/prop-amm/tests/test_helpers.move
+++ b/packages/dapp/contracts/prop-amm/tests/test_helpers.move
@@ -91,7 +91,7 @@ public(package) fun create_sui_currency(): Currency<SUI> {
     currency
 }
 
-/// Creates a DeepBook `Pool<SUI, USDC>` in the test scenario.
+/// Creates a whitelisted DeepBook `Pool<SUI, USDC>` in the test scenario.
 /// Assumes a DeepBook registry already exists as a shared object.
 public(package) fun create_pool(scenario: &mut test_scenario::Scenario, sender: address): ID {
     scenario.next_tx(sender);
@@ -104,6 +104,33 @@ public(package) fun create_pool(scenario: &mut test_scenario::Scenario, sender: 
         constants::lot_size(),
         constants::min_size(),
         true,
+        false,
+        &deepbook_admin_cap,
+        scenario.ctx(),
+    );
+
+    test_scenario::return_shared(deepbook_registry);
+    std::unit_test::destroy(deepbook_admin_cap);
+
+    pool_id
+}
+
+/// Creates a non-whitelisted DeepBook `Pool<SUI, USDC>` in the test scenario, used to
+/// verify that `market::new` rejects pools with non-zero maker/taker fees.
+public(package) fun create_non_whitelisted_pool(
+    scenario: &mut test_scenario::Scenario,
+    sender: address,
+): ID {
+    scenario.next_tx(sender);
+
+    let deepbook_admin_cap = registry::get_admin_cap_for_testing(scenario.ctx());
+    let mut deepbook_registry: deepbook::registry::Registry = scenario.take_shared();
+    let pool_id = pool::create_pool_admin<SUI, USDC>(
+        &mut deepbook_registry,
+        constants::tick_size(),
+        constants::lot_size(),
+        constants::min_size(),
+        false,
         false,
         &deepbook_admin_cap,
         scenario.ctx(),

--- a/packages/dapp/contracts/pyth-mock/Move.toml
+++ b/packages/dapp/contracts/pyth-mock/Move.toml
@@ -3,5 +3,5 @@ name = "local_mock_pyth"
 edition = "2024"
 
 [environments]
-test-publish = "1e949fe3"
+test-publish = "46b6270d"
 localnet = "305e72d1"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,7 +23,7 @@
     "@tanstack/react-query": "^5.90.12",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",
-    "next": "^16.0.11",
+    "next": "^16.2.6",
     "next-themes": "^0.4.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
       next:
-        specifier: '>=16.2.3'
-        version: 16.2.4(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^16.2.6
+        version: 16.2.6(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -828,53 +828,53 @@ packages:
   '@mysten/window-wallet-core@0.1.1':
     resolution: {integrity: sha512-TboJvuqXvJbKy0sqK72kR3RXp7SLkgNfEaNsKWsSUwD+wV9+h/S3wtO+E+yFmPgHgOr8c7HJIQLAdunMssKZtg==}
 
-  '@next/env@16.2.4':
-    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
-  '@next/swc-darwin-arm64@16.2.4':
-    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.4':
-    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.4':
-    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.2.4':
-    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.2.4':
-    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.2.4':
-    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.2.4':
-    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.4':
-    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3000,8 +3000,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.4:
-    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4303,30 +4303,30 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@next/env@16.2.4': {}
+  '@next/env@16.2.6': {}
 
-  '@next/swc-darwin-arm64@16.2.4':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.4':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.4':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.4':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.4':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.4':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.4':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.4':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@noble/curves@1.9.4':
@@ -6495,9 +6495,9 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.2.4(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.6(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@next/env': 16.2.4
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.9
       caniuse-lite: 1.0.30001760
@@ -6506,14 +6506,14 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.4
-      '@next/swc-darwin-x64': 16.2.4
-      '@next/swc-linux-arm64-gnu': 16.2.4
-      '@next/swc-linux-arm64-musl': 16.2.4
-      '@next/swc-linux-x64-gnu': 16.2.4
-      '@next/swc-linux-x64-musl': 16.2.4
-      '@next/swc-win32-arm64-msvc': 16.2.4
-      '@next/swc-win32-x64-msvc': 16.2.4
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
Allow only whitelisted pools for simplicity

Resolves #127

#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Market constructor now validates that DeepBook pools are whitelisted, rejecting non-whitelisted pools with an error.

* **Documentation**
  * Added pool requirements section detailing whitelisted pool support and quote-refresh behavior.

* **Tests**
  * Added test coverage for non-whitelisted pool rejection.

* **Chores**
  * Updated environment configurations across multiple contracts.
  * Updated Next.js dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-sui-amm/pull/139)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->