### PR TITLE
fix(M-02): Forced Re-Quoting via refresh_quotes_permissionless Causes FIFO Priority Loss on DeepBook

### DIFF
--- a/packages/dapp/contracts/prop-amm/Move.lock
+++ b/packages/dapp/contracts/prop-amm/Move.lock
@@ -19,7 +19,7 @@ deps = { MoveStdlib = "MoveStdlib" }
 [pinned.test-publish.deepbook]
 source = { local = "../../../../vendor/deepbookv3/packages/deepbook" }
 use_environment = "test-publish"
-manifest_digest = "A07E009D1B3FCEF9F886F837C413B49FB6609363F4CB092B1211A405CE676059"
+manifest_digest = "4CE7EBF2D294B2073FAC96555A5584741C6DEAA89256AA4FD4FED535D3C79C54"
 deps = { std = "MoveStdlib", sui = "Sui", token = "token" }
 
 [pinned.test-publish.local_mock_pyth]
@@ -35,7 +35,7 @@ manifest_digest = "E14692E4DD4ACA9F0F39F9777C47565F7441A4ACCD1AE2B98E892F12BBAC8
 deps = { deepbook = "deepbook", pyth = "local_mock_pyth", std = "MoveStdlib", sui = "Sui" }
 
 [pinned.test-publish.token]
-source = { local = "../../../../vendor/deepbookv3/packages/token" }
+source = { git = "https://github.com/MystenLabs/deepbookv3.git", subdir = "packages/token", rev = "aacc105fab902376d86283158656debfdc60b387" }
 use_environment = "test-publish"
 manifest_digest = "2963D6B4689ED068546E86F8453FBCA51DCDF68A1C96D681328D2CDACE14B5CF"
 deps = { std = "MoveStdlib", sui = "Sui" }

--- a/packages/dapp/contracts/prop-amm/sources/config.move
+++ b/packages/dapp/contracts/prop-amm/sources/config.move
@@ -25,7 +25,7 @@ const EPriceUnderflow: vector<u8> = "price lower than minimum or underflowed";
 const EPriceOverflow: vector<u8> = "price higher than maximum or overflowed";
 #[error(code = 8)]
 const EInvalidStalePriceToleranceBps: vector<u8> =
-    "stale price tolerance bps must be less than or equal to base spread bps";
+    "stale price tolerance bps must be less than 10000";
 
 // === Constants ===
 
@@ -71,20 +71,21 @@ public struct AMMConfig has drop, store {
     ///     `0` disables skewing (reservation_mid == mid).
     ///     `5_000` shifts the mid by half the `base_spread` at fully one-sided inventory.
     inventory_skew_bps: u64,
-    /// Permissionless-refresh skip threshold in basis points [0..=`base_spread_bps`],
-    /// expressed as the maximum allowed bps drift (in bps of price) between the resting
-    /// ladder and the new would-be ladder. A `refresh_quotes_permissionless` call is skipped
-    /// when the executor has open orders AND the worst-case order drift is below this threshold:
-    ///   `mid_drift_bps + conf_drift_bps < stale_price_tolerance_bps`
+    /// Permissionless-refresh skip threshold in basis points [0..10_000), expressed as a
+    /// fraction of `base_spread`. A `refresh_quotes_permissionless` call is skipped when the
+    /// executor has open orders AND the worst-case order drift is below this fraction of
+    /// `base_spread`:
+    ///   `mid_drift_bps + conf_drift_bps < base_spread_bps * stale_price_tolerance_bps / 10_000`
     /// where `mid_drift_bps = |d(mid)| / last_mid * 10_000` (affects every order) and
     ///       `conf_drift_bps = volatility_multiplier_bps * |d(conf)| / 10_000` (outer orders only).
-    /// Bounded by `base_spread_bps` so a skipped refresh can never hide a shift that would
-    /// move an order across the inner placement distance.
+    /// Bounding the threshold by `base_spread` ensures a skipped refresh can never hide a
+    /// shift that would move an order across the inner placement distance.
     /// Mitigates FIFO-priority grief on DeepBook where any address can force a cancel-and-replace
     /// on every Pyth tick. The admin `refresh_quotes` bypasses this guard.
-    /// E.g:
+    /// E.g (assuming `base_spread_bps = 100`):
     ///     `0` disables the guard (every Pyth tick triggers a refresh; original behavior).
-    ///     `25` skips refreshes when no order would shift by more than 25 bps of price.
+    ///     `5_000` tolerates 50 bps of price drift (50% of `base_spread`) when `conf_ratio_bps`
+    ///             is unchanged.
     stale_price_tolerance_bps: u64,
     /// Restricts every refresh-quotes order to the passive (post-only) book side.
     /// `true` places each order with DeepBook's `post_only` flag: any order that would
@@ -121,7 +122,7 @@ public fun new(
     );
     assert!(outer_balance_bps < HUNDRED_PERCENT_BPS, EInvalidOuterBalanceBps);
     assert!(inventory_skew_bps < HUNDRED_PERCENT_BPS, EInvalidInventorySkewBps);
-    assert!(stale_price_tolerance_bps <= base_spread_bps, EInvalidStalePriceToleranceBps);
+    assert!(stale_price_tolerance_bps < HUNDRED_PERCENT_BPS, EInvalidStalePriceToleranceBps);
     assert!(order_expiration_time_ms > 0, EInvalidOrderExpirationTime);
     assert!(max_price_age_secs > 0, EInvalidMaxPriceAge);
 
@@ -196,20 +197,21 @@ public fun inventory_skew_bps(self: &AMMConfig): u64 {
     self.inventory_skew_bps
 }
 
-/// Permissionless-refresh skip threshold in basis points [0..=`base_spread_bps`],
-/// expressed as the maximum allowed bps drift (in bps of price) between the resting
-/// ladder and the new would-be ladder. A `refresh_quotes_permissionless` call is skipped
-/// when the executor has open orders AND the worst-case order drift is below this threshold:
-///   `mid_drift_bps + conf_drift_bps < stale_price_tolerance_bps`
+/// Permissionless-refresh skip threshold in basis points [0..10_000), expressed as a
+/// fraction of `base_spread`. A `refresh_quotes_permissionless` call is skipped when the
+/// executor has open orders AND the worst-case order drift is below this fraction of
+/// `base_spread`:
+///   `mid_drift_bps + conf_drift_bps < base_spread_bps * stale_price_tolerance_bps / 10_000`
 /// where `mid_drift_bps = |d(mid)| / last_mid * 10_000` (affects every order) and
 ///       `conf_drift_bps = volatility_multiplier_bps * |d(conf)| / 10_000` (outer orders only).
-/// Bounded by `base_spread_bps` so a skipped refresh can never hide a shift that would
-/// move an order across the inner placement distance.
+/// Bounding the threshold by `base_spread` ensures a skipped refresh can never hide a
+/// shift that would move an order across the inner placement distance.
 /// Mitigates FIFO-priority grief on DeepBook where any address can force a cancel-and-replace
 /// on every Pyth tick. The admin `refresh_quotes` bypasses this guard.
-/// E.g:
+/// E.g (assuming `base_spread_bps = 100`):
 ///     `0` disables the guard (every Pyth tick triggers a refresh; original behavior).
-///     `25` skips refreshes when no order would shift by more than 25 bps of price.
+///     `5_000` tolerates 50 bps of price drift (50% of `base_spread`) when `conf_ratio_bps`
+///             is unchanged.
 public fun stale_price_tolerance_bps(self: &AMMConfig): u64 {
     self.stale_price_tolerance_bps
 }
@@ -250,9 +252,10 @@ public(package) fun outer_balance(self: &AMMConfig, balance: u64): u64 {
 }
 
 /// Returns `true` when the worst-case ladder drift (in bps of price) between the resting
-/// ladder and the new would-be ladder is below `stale_price_tolerance_bps`. When this
-/// returns `true`, the permissionless refresh path skips the cancel-and-replace cycle to
-/// preserve FIFO priority.
+/// ladder and the new ladder is below `base_spread_bps * stale_price_tolerance_bps / 10_000`
+/// (`stale_price_tolerance_bps` interpreted as a fraction of `base_spread`).
+/// When this returns `true`, the permissionless refresh path skips the cancel-and-replace
+/// cycle to preserve FIFO priority.
 ///
 /// The worst-case order drift sums the two independent contributions, both in bps of price:
 /// - `mid_drift_bps  = |new_mid - last_mid| / last_mid * 10_000`         (affects every order)
@@ -263,9 +266,9 @@ public(package) fun outer_balance(self: &AMMConfig, balance: u64): u64 {
 /// `mid_drift_bps` (conf_drift is non-negative), so checking the outer alone bounds all
 /// four orders.
 ///
-/// With `stale_price_tolerance_bps == 0` any non-zero drift returns `false` and the guard
-/// is effectively disabled.
-public(package) fun has_stale_tolerance(
+/// With `stale_price_tolerance_bps == 0` the computed tolerance is `0`, so any non-zero
+/// drift returns `false` and the guard is effectively disabled.
+public(package) fun is_stale_tolerant(
     self: &AMMConfig,
     new_mid_price: u64,
     new_conf_ratio_bps: u64,
@@ -282,7 +285,12 @@ public(package) fun has_stale_tolerance(
         .volatility_multiplier_bps
         .mul_div(new_conf_ratio_bps.diff(last_conf_ratio_bps), HUNDRED_PERCENT_BPS);
 
-    mid_drift_bps + conf_drift_bps < self.stale_price_tolerance_bps
+    // Compute absolute tolerance bps.
+    let tolerance_bps = self
+        .base_spread_bps
+        .mul_div(self.stale_price_tolerance_bps, HUNDRED_PERCENT_BPS);
+
+    mid_drift_bps + conf_drift_bps < tolerance_bps
 }
 
 /// Compute the reservation mid: the oracle `mid_price` shifted by up to `base_spread`

--- a/packages/dapp/contracts/prop-amm/sources/config.move
+++ b/packages/dapp/contracts/prop-amm/sources/config.move
@@ -25,7 +25,7 @@ const EPriceUnderflow: vector<u8> = "price lower than minimum or underflowed";
 const EPriceOverflow: vector<u8> = "price higher than maximum or overflowed";
 #[error(code = 8)]
 const EInvalidStalePriceToleranceBps: vector<u8> =
-    "stale price tolerance bps must be less than 10000";
+    "stale price tolerance bps must be less than or equal to base spread bps";
 
 // === Constants ===
 
@@ -71,16 +71,20 @@ public struct AMMConfig has drop, store {
     ///     `0` disables skewing (reservation_mid == mid).
     ///     `5_000` shifts the mid by half the `base_spread` at fully one-sided inventory.
     inventory_skew_bps: u64,
-    /// Permissionless-refresh skip threshold in basis points [0..10_000), expressed as a fraction
-    /// of `base_spread`. A `refresh_quotes_permissionless` call is skipped when the executor
-    /// has open orders AND both the oracle mid and the combined Pyth confidence ratio differ
-    /// from the values cached at the last refresh by less than this threshold (mapped through
-    /// `base_spread` for mid, and through `volatility_multiplier_bps`/`base_spread` for conf).
+    /// Permissionless-refresh skip threshold in basis points [0..=`base_spread_bps`],
+    /// expressed as the maximum allowed bps drift (in bps of price) between the resting
+    /// ladder and the new would-be ladder. A `refresh_quotes_permissionless` call is skipped
+    /// when the executor has open orders AND the worst-case order drift is below this threshold:
+    ///   `mid_drift_bps + conf_drift_bps < stale_price_tolerance_bps`
+    /// where `mid_drift_bps = |d(mid)| / last_mid * 10_000` (affects every order) and
+    ///       `conf_drift_bps = volatility_multiplier_bps * |d(conf)| / 10_000` (outer orders only).
+    /// Bounded by `base_spread_bps` so a skipped refresh can never hide a shift that would
+    /// move an order across the inner placement distance.
     /// Mitigates FIFO-priority grief on DeepBook where any address can force a cancel-and-replace
     /// on every Pyth tick. The admin `refresh_quotes` bypasses this guard.
     /// E.g:
     ///     `0` disables the guard (every Pyth tick triggers a refresh; original behavior).
-    ///     `5_000` skips refreshes that would shift the ladder by less than half of `base_spread`.
+    ///     `25` skips refreshes when no order would shift by more than 25 bps of price.
     stale_price_tolerance_bps: u64,
     /// Restricts every refresh-quotes order to the passive (post-only) book side.
     /// `true` places each order with DeepBook's `post_only` flag: any order that would
@@ -117,10 +121,7 @@ public fun new(
     );
     assert!(outer_balance_bps < HUNDRED_PERCENT_BPS, EInvalidOuterBalanceBps);
     assert!(inventory_skew_bps < HUNDRED_PERCENT_BPS, EInvalidInventorySkewBps);
-    assert!(
-        stale_price_tolerance_bps < HUNDRED_PERCENT_BPS,
-        EInvalidStalePriceToleranceBps,
-    );
+    assert!(stale_price_tolerance_bps <= base_spread_bps, EInvalidStalePriceToleranceBps);
     assert!(order_expiration_time_ms > 0, EInvalidOrderExpirationTime);
     assert!(max_price_age_secs > 0, EInvalidMaxPriceAge);
 
@@ -195,16 +196,20 @@ public fun inventory_skew_bps(self: &AMMConfig): u64 {
     self.inventory_skew_bps
 }
 
-/// Permissionless-refresh skip threshold in basis points [0..10_000), expressed as a fraction
-/// of `base_spread`. A `refresh_quotes_permissionless` call is skipped when the executor
-/// has open orders AND both the oracle mid and the combined Pyth confidence ratio differ
-/// from the values cached at the last refresh by less than this threshold (mapped through
-/// `base_spread` for mid, and through `volatility_multiplier_bps`/`base_spread` for conf).
+/// Permissionless-refresh skip threshold in basis points [0..=`base_spread_bps`],
+/// expressed as the maximum allowed bps drift (in bps of price) between the resting
+/// ladder and the new would-be ladder. A `refresh_quotes_permissionless` call is skipped
+/// when the executor has open orders AND the worst-case order drift is below this threshold:
+///   `mid_drift_bps + conf_drift_bps < stale_price_tolerance_bps`
+/// where `mid_drift_bps = |d(mid)| / last_mid * 10_000` (affects every order) and
+///       `conf_drift_bps = volatility_multiplier_bps * |d(conf)| / 10_000` (outer orders only).
+/// Bounded by `base_spread_bps` so a skipped refresh can never hide a shift that would
+/// move an order across the inner placement distance.
 /// Mitigates FIFO-priority grief on DeepBook where any address can force a cancel-and-replace
 /// on every Pyth tick. The admin `refresh_quotes` bypasses this guard.
 /// E.g:
 ///     `0` disables the guard (every Pyth tick triggers a refresh; original behavior).
-///     `5_000` skips refreshes that would shift the ladder by less than half of `base_spread`.
+///     `25` skips refreshes when no order would shift by more than 25 bps of price.
 public fun stale_price_tolerance_bps(self: &AMMConfig): u64 {
     self.stale_price_tolerance_bps
 }
@@ -244,18 +249,22 @@ public(package) fun outer_balance(self: &AMMConfig, balance: u64): u64 {
     balance.mul_div(self.outer_balance_bps, HUNDRED_PERCENT_BPS)
 }
 
-/// Returns `true` when the new oracle inputs are within `stale_price_tolerance_bps` of the
-/// last placed ones (measured as ladder displacement in price units, taken as a fraction of
-/// `base_spread`). When this returns `true`, the permissionless refresh path skips the
-/// cancel-and-replace cycle to preserve FIFO priority.
+/// Returns `true` when the worst-case ladder drift (in bps of price) between the resting
+/// ladder and the new would-be ladder is below `stale_price_tolerance_bps`. When this
+/// returns `true`, the permissionless refresh path skips the cancel-and-replace cycle to
+/// preserve FIFO priority.
 ///
-/// Both halves of the guard use the same `tolerance` budget:
-/// - `|new_mid - last_mid|` (mid drift in price units)
-/// - `last_mid * volatility_multiplier_bps * |new_conf - last_conf| / 10_000^2`
-///   (outer-order displacement caused by the conf change, in price units)
+/// The worst-case order drift sums the two independent contributions, both in bps of price:
+/// - `mid_drift_bps  = |new_mid - last_mid| / last_mid * 10_000`         (affects every order)
+/// - `conf_drift_bps = volatility_multiplier_bps * |new_conf - last_conf| / 10_000`
+///                                                                       (outer orders only)
 ///
-/// With `stale_price_tolerance_bps == 0`, `tolerance == 0` so any non-zero drift returns
-/// `false` and the guard is effectively disabled.
+/// Outer-order drift `mid_drift_bps + conf_drift_bps` dominates inner-order drift
+/// `mid_drift_bps` (conf_drift is non-negative), so checking the outer alone bounds all
+/// four orders.
+///
+/// With `stale_price_tolerance_bps == 0` any non-zero drift returns `false` and the guard
+/// is effectively disabled.
 public(package) fun has_stale_tolerance(
     self: &AMMConfig,
     new_mid_price: u64,
@@ -263,22 +272,17 @@ public(package) fun has_stale_tolerance(
     last_mid_price: u64,
     last_conf_ratio_bps: u64,
 ): bool {
-    // Tolerance in price units as a fraction of `base_spread`.
-    let tolerance = self
-        .base_spread(last_mid_price)
-        .mul_div(self.stale_price_tolerance_bps, HUNDRED_PERCENT_BPS);
+    // Mid drift in bps of `last_mid_price`.
+    let mid_drift_bps = new_mid_price
+        .diff(last_mid_price)
+        .mul_div(HUNDRED_PERCENT_BPS, last_mid_price);
 
-    // Mid drift in price units.
-    let mid_drift = new_mid_price.diff(last_mid_price);
-
-    // Confidence drift as an outer-order displacement in price units.
-    let conf_diff = new_conf_ratio_bps.diff(last_conf_ratio_bps);
-    let conf_volatility_bps = self
+    // Confidence drift as an outer-order shift in bps of price.
+    let conf_drift_bps = self
         .volatility_multiplier_bps
-        .mul_div(conf_diff, HUNDRED_PERCENT_BPS);
-    let conf_drift = last_mid_price.mul_div(conf_volatility_bps, HUNDRED_PERCENT_BPS);
+        .mul_div(new_conf_ratio_bps.diff(last_conf_ratio_bps), HUNDRED_PERCENT_BPS);
 
-    mid_drift < tolerance && conf_drift < tolerance
+    mid_drift_bps + conf_drift_bps < self.stale_price_tolerance_bps
 }
 
 /// Compute the reservation mid: the oracle `mid_price` shifted by up to `base_spread`

--- a/packages/dapp/contracts/prop-amm/sources/config.move
+++ b/packages/dapp/contracts/prop-amm/sources/config.move
@@ -77,12 +77,14 @@ public struct AMMConfig has drop, store {
     /// `base_spread`:
     ///   `mid_drift_bps + conf_drift_bps < base_spread_bps * stale_price_tolerance_bps / 10_000`
     /// where `mid_drift_bps = |d(mid)| / last_mid * 10_000` (affects every order) and
-    ///       `conf_drift_bps = volatility_multiplier_bps * |d(conf)| / 10_000` (outer orders only).
+    ///       `conf_drift_bps = volatility_multiplier_bps * |d(conf)| / 10_000
+    ///                         * (outer_balance_bps * 2 / 10_000)` (outer orders only, balance-weighted;
+    ///                         `1.0` at the 50/50 split, `0` when `outer_balance_bps == 0`).
     /// Bounding the threshold by `base_spread` ensures a skipped refresh can never hide a
     /// shift that would move an order across the inner placement distance.
     /// Mitigates FIFO-priority grief on DeepBook where any address can force a cancel-and-replace
     /// on every Pyth tick. The admin `refresh_quotes` bypasses this guard.
-    /// E.g (assuming `base_spread_bps = 100`):
+    /// E.g (assuming `base_spread_bps = 100` and `outer_balance_bps = 5_000` — the 50/50 split):
     ///     `0` disables the guard (every Pyth tick triggers a refresh; original behavior).
     ///     `5_000` tolerates 50 bps of price drift (50% of `base_spread`) when `conf_ratio_bps`
     ///             is unchanged.
@@ -203,12 +205,14 @@ public fun inventory_skew_bps(self: &AMMConfig): u64 {
 /// `base_spread`:
 ///   `mid_drift_bps + conf_drift_bps < base_spread_bps * stale_price_tolerance_bps / 10_000`
 /// where `mid_drift_bps = |d(mid)| / last_mid * 10_000` (affects every order) and
-///       `conf_drift_bps = volatility_multiplier_bps * |d(conf)| / 10_000` (outer orders only).
+///       `conf_drift_bps = volatility_multiplier_bps * |d(conf)| / 10_000
+///                         * (outer_balance_bps * 2 / 10_000)` (outer orders only, balance-weighted;
+///                         `1.0` at the 50/50 split, `0` when `outer_balance_bps == 0`).
 /// Bounding the threshold by `base_spread` ensures a skipped refresh can never hide a
 /// shift that would move an order across the inner placement distance.
 /// Mitigates FIFO-priority grief on DeepBook where any address can force a cancel-and-replace
 /// on every Pyth tick. The admin `refresh_quotes` bypasses this guard.
-/// E.g (assuming `base_spread_bps = 100`):
+/// E.g (assuming `base_spread_bps = 100` and `outer_balance_bps = 5_000` — the 50/50 split):
 ///     `0` disables the guard (every Pyth tick triggers a refresh; original behavior).
 ///     `5_000` tolerates 50 bps of price drift (50% of `base_spread`) when `conf_ratio_bps`
 ///             is unchanged.
@@ -259,8 +263,9 @@ public(package) fun outer_balance(self: &AMMConfig, balance: u64): u64 {
 ///
 /// The worst-case order drift sums the two independent contributions, both in bps of price:
 /// - `mid_drift_bps  = |new_mid - last_mid| / last_mid * 10_000`         (affects every order)
-/// - `conf_drift_bps = volatility_multiplier_bps * |new_conf - last_conf| / 10_000`
-///                                                                       (outer orders only)
+/// - `conf_drift_bps = volatility_multiplier_bps * |new_conf - last_conf| / 10_000
+///                    * (outer_balance_bps * 2 / 10_000)`                (outer orders only,
+///                                                                       balance-weighted)
 ///
 /// Outer-order drift `mid_drift_bps + conf_drift_bps` dominates inner-order drift
 /// `mid_drift_bps` (conf_drift is non-negative), so checking the outer alone bounds all
@@ -280,10 +285,12 @@ public(package) fun is_stale_tolerant(
         .diff(last_mid_price)
         .mul_div(HUNDRED_PERCENT_BPS, last_mid_price);
 
-    // Confidence drift as an outer-order shift in bps of price.
+    // Conf moves only the outer order and weighted by `outer_balance_bps * 2 / 10_000`.
+    // So the 50/50 split is `1.0` and conf weight scales to `0` as the ladder becomes inner-only.
     let conf_drift_bps = self
         .volatility_multiplier_bps
-        .mul_div(new_conf_ratio_bps.diff(last_conf_ratio_bps), HUNDRED_PERCENT_BPS);
+        .mul_div(new_conf_ratio_bps.diff(last_conf_ratio_bps), HUNDRED_PERCENT_BPS)
+        .mul_div(self.outer_balance_bps * 2, HUNDRED_PERCENT_BPS);
 
     // Compute absolute tolerance bps.
     let tolerance_bps = self

--- a/packages/dapp/contracts/prop-amm/sources/config.move
+++ b/packages/dapp/contracts/prop-amm/sources/config.move
@@ -23,6 +23,9 @@ const EInvalidInventorySkewBps: vector<u8> = "inventory skew bps must be less th
 const EPriceUnderflow: vector<u8> = "price lower than minimum or underflowed";
 #[error(code = 7)]
 const EPriceOverflow: vector<u8> = "price higher than maximum or overflowed";
+#[error(code = 8)]
+const EInvalidStalePriceToleranceBps: vector<u8> =
+    "stale price tolerance bps must be less than 10000";
 
 // === Constants ===
 
@@ -68,6 +71,17 @@ public struct AMMConfig has drop, store {
     ///     `0` disables skewing (reservation_mid == mid).
     ///     `5_000` shifts the mid by half the `base_spread` at fully one-sided inventory.
     inventory_skew_bps: u64,
+    /// Permissionless-refresh skip threshold in basis points [0..10_000), expressed as a fraction
+    /// of `base_spread`. A `refresh_quotes_permissionless` call is skipped when the executor
+    /// has open orders AND both the oracle mid and the combined Pyth confidence ratio differ
+    /// from the values cached at the last refresh by less than this threshold (mapped through
+    /// `base_spread` for mid, and through `volatility_multiplier_bps`/`base_spread` for conf).
+    /// Mitigates FIFO-priority grief on DeepBook where any address can force a cancel-and-replace
+    /// on every Pyth tick. The admin `refresh_quotes` bypasses this guard.
+    /// E.g:
+    ///     `0` disables the guard (every Pyth tick triggers a refresh; original behavior).
+    ///     `5_000` skips refreshes that would shift the ladder by less than half of `base_spread`.
+    stale_price_tolerance_bps: u64,
     /// Restricts every refresh-quotes order to the passive (post-only) book side.
     /// `true` places each order with DeepBook's `post_only` flag: any order that would
     /// cross the resting book aborts the whole `refresh_quotes` transaction, leaving the
@@ -93,6 +107,7 @@ public fun new(
     max_conf_ratio_bps: u64,
     outer_balance_bps: u64,
     inventory_skew_bps: u64,
+    stale_price_tolerance_bps: u64,
     post_only: bool,
 ): AMMConfig {
     assert!(base_spread_bps > 0 && base_spread_bps < HUNDRED_PERCENT_BPS, EInvalidBaseSpreadBps);
@@ -102,6 +117,10 @@ public fun new(
     );
     assert!(outer_balance_bps < HUNDRED_PERCENT_BPS, EInvalidOuterBalanceBps);
     assert!(inventory_skew_bps < HUNDRED_PERCENT_BPS, EInvalidInventorySkewBps);
+    assert!(
+        stale_price_tolerance_bps < HUNDRED_PERCENT_BPS,
+        EInvalidStalePriceToleranceBps,
+    );
     assert!(order_expiration_time_ms > 0, EInvalidOrderExpirationTime);
     assert!(max_price_age_secs > 0, EInvalidMaxPriceAge);
 
@@ -113,6 +132,7 @@ public fun new(
         max_conf_ratio_bps,
         outer_balance_bps,
         inventory_skew_bps,
+        stale_price_tolerance_bps,
         post_only,
     }
 }
@@ -175,6 +195,20 @@ public fun inventory_skew_bps(self: &AMMConfig): u64 {
     self.inventory_skew_bps
 }
 
+/// Permissionless-refresh skip threshold in basis points [0..10_000), expressed as a fraction
+/// of `base_spread`. A `refresh_quotes_permissionless` call is skipped when the executor
+/// has open orders AND both the oracle mid and the combined Pyth confidence ratio differ
+/// from the values cached at the last refresh by less than this threshold (mapped through
+/// `base_spread` for mid, and through `volatility_multiplier_bps`/`base_spread` for conf).
+/// Mitigates FIFO-priority grief on DeepBook where any address can force a cancel-and-replace
+/// on every Pyth tick. The admin `refresh_quotes` bypasses this guard.
+/// E.g:
+///     `0` disables the guard (every Pyth tick triggers a refresh; original behavior).
+///     `5_000` skips refreshes that would shift the ladder by less than half of `base_spread`.
+public fun stale_price_tolerance_bps(self: &AMMConfig): u64 {
+    self.stale_price_tolerance_bps
+}
+
 /// Returns whether `refresh_quotes` should place orders as post-only.
 /// `true` aborts the whole refresh if any order would cross the resting book, preserving
 /// the previous quotes. `false` allows the crossing portion to execute as a taker.
@@ -208,6 +242,43 @@ public(package) fun outer_spread(self: &AMMConfig, mid_price: u64, conf_ratio_bp
 /// Compute the amount of `balance` that should be allocated to the outer (volatility) spread order.
 public(package) fun outer_balance(self: &AMMConfig, balance: u64): u64 {
     balance.mul_div(self.outer_balance_bps, HUNDRED_PERCENT_BPS)
+}
+
+/// Returns `true` when the new oracle inputs are within `stale_price_tolerance_bps` of the
+/// last placed ones (measured as ladder displacement in price units, taken as a fraction of
+/// `base_spread`). When this returns `true`, the permissionless refresh path skips the
+/// cancel-and-replace cycle to preserve FIFO priority.
+///
+/// Both halves of the guard use the same `tolerance` budget:
+/// - `|new_mid - last_mid|` (mid drift in price units)
+/// - `last_mid * volatility_multiplier_bps * |new_conf - last_conf| / 10_000^2`
+///   (outer-order displacement caused by the conf change, in price units)
+///
+/// With `stale_price_tolerance_bps == 0`, `tolerance == 0` so any non-zero drift returns
+/// `false` and the guard is effectively disabled.
+public(package) fun has_stale_tolerance(
+    self: &AMMConfig,
+    new_mid_price: u64,
+    new_conf_ratio_bps: u64,
+    last_mid_price: u64,
+    last_conf_ratio_bps: u64,
+): bool {
+    // Tolerance in price units as a fraction of `base_spread`.
+    let tolerance = self
+        .base_spread(last_mid_price)
+        .mul_div(self.stale_price_tolerance_bps, HUNDRED_PERCENT_BPS);
+
+    // Mid drift in price units.
+    let mid_drift = new_mid_price.diff(last_mid_price);
+
+    // Confidence drift as an outer-order displacement in price units.
+    let conf_diff = new_conf_ratio_bps.diff(last_conf_ratio_bps);
+    let conf_volatility_bps = self
+        .volatility_multiplier_bps
+        .mul_div(conf_diff, HUNDRED_PERCENT_BPS);
+    let conf_drift = last_mid_price.mul_div(conf_volatility_bps, HUNDRED_PERCENT_BPS);
+
+    mid_drift < tolerance && conf_drift < tolerance
 }
 
 /// Compute the reservation mid: the oracle `mid_price` shifted by up to `base_spread`

--- a/packages/dapp/contracts/prop-amm/sources/executor.move
+++ b/packages/dapp/contracts/prop-amm/sources/executor.move
@@ -485,7 +485,7 @@ fun refresh_quotes_inner<BaseAsset, QuoteAsset>(
 
     // Cache price and confidence that drove this placement, so the permissionless-refresh
     // skip guard can compare them against the next call's oracle inputs.
-    self.market.update_price_and_conf(oracle_mid_price, conf_ratio_bps);
+    self.market.set_price_and_conf(oracle_mid_price, conf_ratio_bps);
 
     events::emit_quote_updated(self.id(), oracle_mid_price, orders);
 }

--- a/packages/dapp/contracts/prop-amm/sources/executor.move
+++ b/packages/dapp/contracts/prop-amm/sources/executor.move
@@ -339,7 +339,7 @@ public fun refresh_quotes_permissionless<BaseAsset, QuoteAsset>(
     if (has_open_orders && last_mid_price.is_some() && last_conf_ratio_bps.is_some()) {
         let is_within_tolerance = self
             .config
-            .has_stale_tolerance(
+            .is_stale_tolerant(
                 oracle_mid_price,
                 conf_ratio_bps,
                 last_mid_price.destroy_some(),
@@ -483,9 +483,9 @@ fun refresh_quotes_inner<BaseAsset, QuoteAsset>(
     ];
     let orders = self.try_place_limit_orders(pool, &trade_proof, order_params, clock, ctx);
 
-    // Cache the inputs that drove this placement so the permissionless-refresh skip guard
-    // can compare them against the next call's oracle inputs.
-    self.market.record_last_quote_inputs(oracle_mid_price, conf_ratio_bps);
+    // Cache price and confidence that drove this placement, so the permissionless-refresh
+    // skip guard can compare them against the next call's oracle inputs.
+    self.market.set_price_and_conf(oracle_mid_price, conf_ratio_bps);
 
     events::emit_quote_updated(self.id(), oracle_mid_price, orders);
 }

--- a/packages/dapp/contracts/prop-amm/sources/executor.move
+++ b/packages/dapp/contracts/prop-amm/sources/executor.move
@@ -315,7 +315,7 @@ public fun refresh_quotes_permissionless<BaseAsset, QuoteAsset>(
     // Protects from calling permissionless quote refresh with old pricing,
     // that would force the market maker to resubmit orders and lose priority.
     let has_open_orders = self.has_open_orders(pool);
-    let is_price_updated = self.market.try_update_publish_time(base_pyth_price, quote_pyth_price);
+    let is_price_updated = self.market.try_update_publish_times(base_pyth_price, quote_pyth_price);
     if (has_open_orders && !is_price_updated) {
         return
     };
@@ -485,7 +485,7 @@ fun refresh_quotes_inner<BaseAsset, QuoteAsset>(
 
     // Cache price and confidence that drove this placement, so the permissionless-refresh
     // skip guard can compare them against the next call's oracle inputs.
-    self.market.set_price_and_conf(oracle_mid_price, conf_ratio_bps);
+    self.market.update_price_and_conf(oracle_mid_price, conf_ratio_bps);
 
     events::emit_quote_updated(self.id(), oracle_mid_price, orders);
 }

--- a/packages/dapp/contracts/prop-amm/sources/executor.move
+++ b/packages/dapp/contracts/prop-amm/sources/executor.move
@@ -136,9 +136,10 @@ public fun create(market: Market, config: AMMConfig, ctx: &mut TxContext): (Exec
     (executor, executor_cap)
 }
 
-/// Replaces AMM configuration. Resets the cached Pyth publish timestamps so the next
-/// `refresh_quotes_permissionless` call re-prices even when the oracle timestamp has not
-/// advanced. Requires the matching market maker executor capability.
+/// Replaces AMM configuration. Resets the cached freshness state (Pyth publish timestamps
+/// and last quoted mid / conf ratio) so the next `refresh_quotes_permissionless` call
+/// re-prices unconditionally even when the oracle timestamp or value has not advanced.
+/// Requires the matching market maker executor capability.
 /// To reflect trading configuration immediately, `refresh_quotes_permissionless` (or the
 /// admin `refresh_quotes`) should be called within a single PTB.
 public fun update_config(self: &mut Executor, cap: &AdminCap, config: AMMConfig) {
@@ -147,7 +148,7 @@ public fun update_config(self: &mut Executor, cap: &AdminCap, config: AMMConfig)
 
     events::emit_executor_config_updated(self.id());
 
-    self.market.reset_price_publish_times();
+    self.market.reset_freshness_state();
     self.config = config;
 }
 
@@ -330,6 +331,25 @@ public fun refresh_quotes_permissionless<BaseAsset, QuoteAsset>(
             self.config.max_conf_ratio_bps(),
         );
 
+    // Skip refresh when the new oracle inputs are within `stale_price_tolerance_bps` of the
+    // last placed ones.
+    // Defends against FIFO-priority on Pyth ticks that would barely move the ladder.
+    let last_mid_price = self.market.mid_price();
+    let last_conf_ratio_bps = self.market.conf_ratio_bps();
+    if (has_open_orders && last_mid_price.is_some() && last_conf_ratio_bps.is_some()) {
+        let is_within_tolerance = self
+            .config
+            .has_stale_tolerance(
+                oracle_mid_price,
+                conf_ratio_bps,
+                last_mid_price.destroy_some(),
+                last_conf_ratio_bps.destroy_some(),
+            );
+        if (is_within_tolerance) {
+            return
+        };
+    };
+
     self.refresh_quotes_inner(pool, oracle_mid_price, conf_ratio_bps, clock, ctx);
 }
 
@@ -462,6 +482,10 @@ fun refresh_quotes_inner<BaseAsset, QuoteAsset>(
         LimitOrderParams { price: ask_outer, quantity: ask_outer_quantity, is_bid: false },
     ];
     let orders = self.try_place_limit_orders(pool, &trade_proof, order_params, clock, ctx);
+
+    // Cache the inputs that drove this placement so the permissionless-refresh skip guard
+    // can compare them against the next call's oracle inputs.
+    self.market.record_last_quote_inputs(oracle_mid_price, conf_ratio_bps);
 
     events::emit_quote_updated(self.id(), oracle_mid_price, orders);
 }

--- a/packages/dapp/contracts/prop-amm/sources/market.move
+++ b/packages/dapp/contracts/prop-amm/sources/market.move
@@ -39,8 +39,9 @@ const HUNDRED_PERCENT_BPS_U128: u128 = 10_000;
 
 // === Structs ===
 
-/// Market metadata: pool identity, cached asset decimals, Pyth feed identifiers, and the
-/// latest observed publish timestamps used to detect replayed oracle prices.
+/// Market metadata: pool identity, cached asset decimals, Pyth feed identifiers, the
+/// latest observed publish timestamps used to detect replayed oracle prices, and the
+/// mid price mid confidence ratio recorded at the last quote refresh.
 public struct Market has drop, store {
     /// ID of the associated pool.
     pool_id: ID,
@@ -48,6 +49,14 @@ public struct Market has drop, store {
     base: MarketCurrency,
     /// Quote asset metadata.
     quote: MarketCurrency,
+    /// DeepBook mid price (base/quote) recorded at the last successful quote refresh.
+    /// `none()` before the first refresh and after `reset_freshness_state` (e.g. on
+    /// `update_config`). Compared against the new oracle mid in the permissionless-refresh
+    /// skip guard, alongside `conf_ratio_bps`.
+    mid_price: Option<u64>,
+    /// Combined Pyth confidence-to-price ratio (bps) recorded at the last successful quote
+    /// refresh. See `mid_price` for the freshness guard it participates in.
+    conf_ratio_bps: Option<u64>,
 }
 
 /// Per-side (base or quote) asset metadata.
@@ -113,6 +122,8 @@ public fun new<BaseAsset, QuoteAsset>(
             pyth_price_feed_id: quote_pyth_price_feed_id,
             price_publish_time: option::none(),
         },
+        mid_price: option::none(),
+        conf_ratio_bps: option::none(),
     }
 }
 
@@ -187,6 +198,16 @@ public fun quote_price_publish_time(self: &Market): Option<u64> {
     self.quote.price_publish_time
 }
 
+/// Returns the mid price (base/quote) recorded at the last successful quote refresh, if any.
+public fun mid_price(self: &Market): Option<u64> {
+    self.mid_price
+}
+
+/// Returns the confidence-to-price ratio (bps) recorded at the last successful quote refresh, if any.
+public fun conf_ratio_bps(self: &Market): Option<u64> {
+    self.conf_ratio_bps
+}
+
 // === Package Functions ===
 
 /// Attempts to advance the cached base and quote publish times to the incoming price
@@ -222,11 +243,27 @@ public(package) fun try_update_publish_time(
     update_base_price_ts || update_quote_price_ts
 }
 
-/// Clears cached base and quote price publish timestamps so the next oracle read is not
-/// treated as stale/replayed.
-public(package) fun reset_price_publish_times(self: &mut Market) {
+/// Clears all cached freshness state — base/quote price publish timestamps and the last
+/// quoted mid / conf ratio. After this, the next `refresh_quotes_permissionless` call
+/// re-prices unconditionally (publish-time guard sees fresh timestamps, stale-tolerance guard
+/// sees `none()` last values).
+public(package) fun reset_freshness_state(self: &mut Market) {
     self.base.price_publish_time = option::none();
     self.quote.price_publish_time = option::none();
+    self.mid_price = option::none();
+    self.conf_ratio_bps = option::none();
+}
+
+/// Records the oracle inputs (`mid_price` and combined `conf_ratio_bps`) used for the last
+/// successful quote refresh. Consumed by the permissionless-refresh skip guard on the next
+/// call.
+public(package) fun record_last_quote_inputs(
+    self: &mut Market,
+    mid_price: u64,
+    conf_ratio_bps: u64,
+) {
+    self.mid_price = option::some(mid_price);
+    self.conf_ratio_bps = option::some(conf_ratio_bps);
 }
 
 /// Derive the DeepBook base/quote price and the combined confidence-to-price ratio (in basis

--- a/packages/dapp/contracts/prop-amm/sources/market.move
+++ b/packages/dapp/contracts/prop-amm/sources/market.move
@@ -257,11 +257,7 @@ public(package) fun reset_freshness_state(self: &mut Market) {
 /// Records the oracle inputs (`mid_price` and combined `conf_ratio_bps`) used for the last
 /// successful quote refresh. Consumed by the permissionless-refresh skip guard on the next
 /// call.
-public(package) fun record_last_quote_inputs(
-    self: &mut Market,
-    mid_price: u64,
-    conf_ratio_bps: u64,
-) {
+public(package) fun set_price_and_conf(self: &mut Market, mid_price: u64, conf_ratio_bps: u64) {
     self.mid_price = option::some(mid_price);
     self.conf_ratio_bps = option::some(conf_ratio_bps);
 }

--- a/packages/dapp/contracts/prop-amm/sources/market.move
+++ b/packages/dapp/contracts/prop-amm/sources/market.move
@@ -245,7 +245,7 @@ public(package) fun try_update_publish_times(
 /// Records the oracle inputs (`mid_price` and combined `conf_ratio_bps`) used for the last
 /// successful quote refresh. Consumed by the permissionless-refresh skip guard on the next
 /// call.
-public(package) fun update_price_and_conf(self: &mut Market, mid_price: u64, conf_ratio_bps: u64) {
+public(package) fun set_price_and_conf(self: &mut Market, mid_price: u64, conf_ratio_bps: u64) {
     self.mid_price = option::some(mid_price);
     self.conf_ratio_bps = option::some(conf_ratio_bps);
 }

--- a/packages/dapp/contracts/prop-amm/sources/market.move
+++ b/packages/dapp/contracts/prop-amm/sources/market.move
@@ -49,13 +49,12 @@ public struct Market has drop, store {
     base: MarketCurrency,
     /// Quote asset metadata.
     quote: MarketCurrency,
-    /// DeepBook mid price (base/quote) recorded at the last successful quote refresh.
+    /// Mid price (base/quote) recorded at the last successful quote refresh.
     /// `none()` before the first refresh and after `reset_freshness_state` (e.g. on
-    /// `update_config`). Compared against the new oracle mid in the permissionless-refresh
-    /// skip guard, alongside `conf_ratio_bps`.
+    /// `update_config`).
     mid_price: Option<u64>,
-    /// Combined Pyth confidence-to-price ratio (bps) recorded at the last successful quote
-    /// refresh. See `mid_price` for the freshness guard it participates in.
+    /// Combined confidence-to-price ratio (bps) recorded at the last successful quote
+    /// refresh.
     conf_ratio_bps: Option<u64>,
 }
 
@@ -67,7 +66,7 @@ public struct MarketCurrency has drop, store {
     decimals: u8,
     /// Pyth price feed identifier bytes (32 bytes).
     pyth_price_feed_id: vector<u8>,
-    /// Latest observed Pyth publish timestamp for this feed, if any.
+    /// Latest observed publish timestamp for this market currency, if any.
     price_publish_time: Option<u64>,
 }
 

--- a/packages/dapp/contracts/prop-amm/sources/market.move
+++ b/packages/dapp/contracts/prop-amm/sources/market.move
@@ -214,7 +214,7 @@ public fun conf_ratio_bps(self: &Market): Option<u64> {
 /// Returns `true` when at least one feed advanced.
 /// Returns `false` when both feeds are stale (no cache mutation).
 /// The caller is expected to skip any downstream refresh work when this returns `false`.
-public(package) fun try_update_publish_time(
+public(package) fun try_update_publish_times(
     self: &mut Market,
     base_price: Price,
     quote_price: Price,
@@ -242,6 +242,14 @@ public(package) fun try_update_publish_time(
     update_base_price_ts || update_quote_price_ts
 }
 
+/// Records the oracle inputs (`mid_price` and combined `conf_ratio_bps`) used for the last
+/// successful quote refresh. Consumed by the permissionless-refresh skip guard on the next
+/// call.
+public(package) fun update_price_and_conf(self: &mut Market, mid_price: u64, conf_ratio_bps: u64) {
+    self.mid_price = option::some(mid_price);
+    self.conf_ratio_bps = option::some(conf_ratio_bps);
+}
+
 /// Clears all cached freshness state — base/quote price publish timestamps and the last
 /// quoted mid / conf ratio. After this, the next `refresh_quotes_permissionless` call
 /// re-prices unconditionally (publish-time guard sees fresh timestamps, stale-tolerance guard
@@ -251,14 +259,6 @@ public(package) fun reset_freshness_state(self: &mut Market) {
     self.quote.price_publish_time = option::none();
     self.mid_price = option::none();
     self.conf_ratio_bps = option::none();
-}
-
-/// Records the oracle inputs (`mid_price` and combined `conf_ratio_bps`) used for the last
-/// successful quote refresh. Consumed by the permissionless-refresh skip guard on the next
-/// call.
-public(package) fun set_price_and_conf(self: &mut Market, mid_price: u64, conf_ratio_bps: u64) {
-    self.mid_price = option::some(mid_price);
-    self.conf_ratio_bps = option::some(conf_ratio_bps);
 }
 
 /// Derive the DeepBook base/quote price and the combined confidence-to-price ratio (in basis

--- a/packages/dapp/contracts/prop-amm/sources/market.move
+++ b/packages/dapp/contracts/prop-amm/sources/market.move
@@ -42,7 +42,7 @@ const HUNDRED_PERCENT_BPS_U128: u128 = 10_000;
 
 /// Market metadata: pool identity, cached asset decimals, Pyth feed identifiers, the
 /// latest observed publish timestamps used to detect replayed oracle prices, and the
-/// mid price mid confidence ratio recorded at the last quote refresh.
+/// mid price and mid confidence ratio recorded at the last quote refresh.
 public struct Market has drop, store {
     /// ID of the associated pool.
     pool_id: ID,
@@ -243,6 +243,15 @@ public(package) fun try_update_publish_times(
     update_base_price_timestamp || update_quote_price_timestamp
 }
 
+/// Sets the cached base and quote price publish timestamps to the current clock time.
+/// Subsequent `try_update_publish_times` calls require a strictly later Pyth timestamp to advance the
+/// cache.
+public(package) fun set_latest_publish_times(self: &mut Market, clock: &Clock) {
+    let timestamp_s = clock.timestamp_ms() / 1000;
+    self.base.price_publish_time = option::some(timestamp_s);
+    self.quote.price_publish_time = option::some(timestamp_s);
+}
+
 /// Records the oracle inputs (`mid_price` and combined `conf_ratio_bps`) used for the last
 /// successful quote refresh. Consumed by the permissionless-refresh skip guard on the next
 /// call.
@@ -260,15 +269,6 @@ public(package) fun reset_freshness_state(self: &mut Market) {
     self.quote.price_publish_time = option::none();
     self.mid_price = option::none();
     self.conf_ratio_bps = option::none();
-}
-
-/// Sets the cached base and quote price publish timestamps to the current clock time.
-/// Subsequent `try_update_publish_time` calls require a strictly later Pyth timestamp to advance the
-/// cache.
-public(package) fun set_latest_publish_times(self: &mut Market, clock: &Clock) {
-    let timestamp_s = clock.timestamp_ms() / 1000;
-    self.base.price_publish_time = option::some(timestamp_s);
-    self.quote.price_publish_time = option::some(timestamp_s);
 }
 
 /// Derive the DeepBook base/quote price and the combined confidence-to-price ratio (in basis

--- a/packages/dapp/contracts/prop-amm/tests/config_tests.move
+++ b/packages/dapp/contracts/prop-amm/tests/config_tests.move
@@ -78,7 +78,7 @@ fun create_amm_config_rejects_zero_max_price_age() {
 #[test]
 fun create_amm_config_accepts_order_expiration_equal_to_max_price_age() {
     // 30_000 ms == 30 s * 1000: boundary is inclusive.
-    let amm_config = config::new(100, 10_000, 30_000, 30, 1000, 5000, 0, true);
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1000, 5000, 0, 0, true);
 
     assert_eq!(amm_config.order_expiration_time_ms(), 30_000);
     assert_eq!(amm_config.max_price_age_secs(), 30);
@@ -87,7 +87,7 @@ fun create_amm_config_accepts_order_expiration_equal_to_max_price_age() {
 #[test, expected_failure(abort_code = config::EOrderExpirationExceedsPriceAge)]
 fun create_amm_config_rejects_order_expiration_above_max_price_age() {
     // 30_001 ms > 30 s * 1000: even by 1 ms must fail.
-    let _amm_config = config::new(100, 10_000, 30_001, 30, 1000, 5000, 0, true);
+    let _amm_config = config::new(100, 10_000, 30_001, 30, 1000, 5000, 0, 0, true);
 
     abort
 }
@@ -146,6 +146,7 @@ fun reservation_mid_handles_large_inventories_without_overflow() {
         1000,
         5_000,
         5_000,
+        0,
         true,
     );
 

--- a/packages/dapp/contracts/prop-amm/tests/config_tests.move
+++ b/packages/dapp/contracts/prop-amm/tests/config_tests.move
@@ -161,3 +161,72 @@ fun reservation_mid_handles_large_inventories_without_overflow() {
     // adjusted_shift = shift * inventory_skew_bps / 10_000 = 5e16.
     assert_eq!(reservation_mid, mid_price - 50_000_000_000_000_000);
 }
+
+#[test]
+fun is_stale_tolerant_returns_true_when_drift_is_zero() {
+    // tolerance = base_spread_bps * stale_price_tolerance_bps / 10_000 = 100 * 5_000 / 10_000 = 50 bps.
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1_000, 5_000, 0, 5_000, true);
+
+    // mid_drift = 0, conf_drift = 0, tolerance = 50 → 0 < 50 → skip.
+    assert_eq!(amm_config.is_stale_tolerant(1_000_000, 100, 1_000_000, 100), true);
+}
+
+#[test]
+fun is_stale_tolerant_returns_false_when_tolerance_is_zero() {
+    // stale_price_tolerance_bps = 0 disables the guard: tolerance = 0 and the comparison is strict.
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1_000, 5_000, 0, 0, true);
+
+    // Identical inputs still fail 0 < 0, so refresh proceeds.
+    assert_eq!(amm_config.is_stale_tolerant(1_000_000, 100, 1_000_000, 100), false);
+}
+
+#[test]
+fun is_stale_tolerant_returns_true_when_mid_drift_below_tolerance() {
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1_000, 5_000, 0, 5_000, true);
+
+    // mid_drift = 3_000 / 1_000_000 * 10_000 = 30 bps; tolerance = 50 → skip.
+    assert_eq!(amm_config.is_stale_tolerant(1_003_000, 100, 1_000_000, 100), true);
+}
+
+#[test]
+fun is_stale_tolerant_returns_false_when_mid_drift_above_tolerance() {
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1_000, 5_000, 0, 5_000, true);
+
+    // mid_drift = 10_000 / 1_000_000 * 10_000 = 100 bps; tolerance = 50 → refresh.
+    assert_eq!(amm_config.is_stale_tolerant(1_010_000, 100, 1_000_000, 100), false);
+}
+
+#[test]
+fun is_stale_tolerant_returns_false_when_drift_equals_tolerance() {
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1_000, 5_000, 0, 5_000, true);
+
+    // mid_drift = 5_000 / 1_000_000 * 10_000 = 50 bps; tolerance = 50 → 50 < 50 is false → refresh.
+    assert_eq!(amm_config.is_stale_tolerant(1_005_000, 100, 1_000_000, 100), false);
+}
+
+#[test]
+fun is_stale_tolerant_returns_false_when_conf_drift_above_tolerance() {
+    // outer_balance_bps = 5_000 (50/50 split) → conf weight = 5_000 * 2 / 10_000 = 1.0.
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1_000, 5_000, 0, 5_000, true);
+
+    // mid_drift = 0; conf_drift = 10_000 * 100 / 10_000 * 10_000 / 10_000 = 100 bps;
+    // tolerance = 50 → 100 < 50 is false → refresh.
+    assert_eq!(amm_config.is_stale_tolerant(1_000_000, 200, 1_000_000, 100), false);
+}
+
+#[test]
+fun is_stale_tolerant_zeros_conf_drift_when_outer_balance_is_zero() {
+    // outer_balance_bps = 0 → conf weight = 0 → conf_drift collapses to 0 regardless of value.
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1_000, 0, 0, 5_000, true);
+
+    // Huge conf change is ignored; mid_drift = 0 → 0 < 50 → skip.
+    assert_eq!(amm_config.is_stale_tolerant(1_000_000, 10_000, 1_000_000, 0), true);
+}
+
+#[test]
+fun is_stale_tolerant_sums_mid_and_conf_drift() {
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1_000, 5_000, 0, 5_000, true);
+
+    // mid_drift = 30 bps; conf_drift = 25 bps; sum = 55; tolerance = 50 → refresh.
+    assert_eq!(amm_config.is_stale_tolerant(1_003_000, 125, 1_000_000, 100), false);
+}

--- a/packages/dapp/contracts/prop-amm/tests/config_tests.move
+++ b/packages/dapp/contracts/prop-amm/tests/config_tests.move
@@ -18,6 +18,7 @@ fun create_amm_config_builds_expected_config() {
         1000,
         5000,
         0,
+        0,
         true,
     );
 
@@ -28,89 +29,90 @@ fun create_amm_config_builds_expected_config() {
     assert_eq!(amm_config.max_conf_ratio_bps(), 1000);
     assert_eq!(amm_config.outer_balance_bps(), 5000);
     assert_eq!(amm_config.inventory_skew_bps(), 0);
+    assert_eq!(amm_config.stale_price_tolerance_bps(), 0);
     assert_eq!(amm_config.post_only(), true);
 }
 
 #[test, expected_failure(abort_code = config::EInvalidBaseSpreadBps)]
 fun create_amm_config_rejects_zero_base_spread_bps() {
-    let _amm_config = config::new(0, 10_000, 30_000, 30, 1000, 5000, 0, true);
+    let _amm_config = config::new(0, 10_000, 30_000, 30, 1000, 5000, 0, 0, true);
 
     abort
 }
 
 #[test, expected_failure(abort_code = config::EInvalidBaseSpreadBps)]
 fun create_amm_config_rejects_base_spread_bps_above_ten_thousand() {
-    let _amm_config = config::new(10_001, 10_000, 30_000, 30, 1000, 5000, 0, true);
+    let _amm_config = config::new(10_001, 10_000, 30_000, 30, 1000, 5000, 0, 0, true);
 
     abort
 }
 
 #[test, expected_failure(abort_code = config::EInvalidMaxConfRatioBps)]
 fun create_amm_config_rejects_zero_max_conf_ratio_bps() {
-    let _amm_config = config::new(100, 10_000, 30_000, 30, 0, 5000, 0, true);
+    let _amm_config = config::new(100, 10_000, 30_000, 30, 0, 5000, 0, 0, true);
 
     abort
 }
 
 #[test, expected_failure(abort_code = config::EInvalidMaxConfRatioBps)]
 fun create_amm_config_rejects_max_conf_ratio_bps_above_ten_thousand() {
-    let _amm_config = config::new(100, 10_000, 30_000, 30, 10_001, 5000, 0, true);
+    let _amm_config = config::new(100, 10_000, 30_000, 30, 10_001, 5000, 0, 0, true);
 
     abort
 }
 
 #[test, expected_failure(abort_code = config::EInvalidOrderExpirationTime)]
 fun create_amm_config_rejects_zero_order_expiration_time() {
-    let _amm_config = config::new(100, 10_000, 0, 30, 1000, 5000, 0, true);
+    let _amm_config = config::new(100, 10_000, 0, 30, 1000, 5000, 0, 0, true);
 
     abort
 }
 
 #[test, expected_failure(abort_code = config::EInvalidMaxPriceAge)]
 fun create_amm_config_rejects_zero_max_price_age() {
-    let _amm_config = config::new(100, 10_000, 30_000, 0, 1000, 5000, 0, true);
+    let _amm_config = config::new(100, 10_000, 30_000, 0, 1000, 5000, 0, 0, true);
 
     abort
 }
 
 #[test]
 fun create_amm_config_accepts_zero_outer_balance_bps() {
-    let amm_config = config::new(100, 10_000, 30_000, 30, 1000, 0, 0, true);
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1000, 0, 0, 0, true);
 
     assert_eq!(amm_config.outer_balance_bps(), 0);
 }
 
 #[test, expected_failure(abort_code = config::EInvalidOuterBalanceBps)]
 fun create_amm_config_rejects_outer_balance_bps_at_hundred_percent() {
-    let _amm_config = config::new(100, 10_000, 30_000, 30, 1000, 10_000, 0, true);
+    let _amm_config = config::new(100, 10_000, 30_000, 30, 1000, 10_000, 0, 0, true);
 
     abort
 }
 
 #[test, expected_failure(abort_code = config::EInvalidOuterBalanceBps)]
 fun create_amm_config_rejects_outer_balance_bps_above_ten_thousand() {
-    let _amm_config = config::new(100, 10_000, 30_000, 30, 1000, 10_001, 0, true);
+    let _amm_config = config::new(100, 10_000, 30_000, 30, 1000, 10_001, 0, 0, true);
 
     abort
 }
 
 #[test]
 fun create_amm_config_accepts_inventory_skew_bps_just_below_hundred_percent() {
-    let amm_config = config::new(100, 10_000, 30_000, 30, 1000, 5000, 9_999, true);
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1000, 5000, 9_999, 0, true);
 
     assert_eq!(amm_config.inventory_skew_bps(), 9_999);
 }
 
 #[test, expected_failure(abort_code = config::EInvalidInventorySkewBps)]
 fun create_amm_config_rejects_inventory_skew_bps_at_hundred_percent() {
-    let _amm_config = config::new(100, 10_000, 30_000, 30, 1000, 5000, 10_000, true);
+    let _amm_config = config::new(100, 10_000, 30_000, 30, 1000, 5000, 10_000, 0, true);
 
     abort
 }
 
 #[test, expected_failure(abort_code = config::EInvalidInventorySkewBps)]
 fun create_amm_config_rejects_inventory_skew_bps_above_ten_thousand() {
-    let _amm_config = config::new(100, 10_000, 30_000, 30, 1000, 5000, 10_001, true);
+    let _amm_config = config::new(100, 10_000, 30_000, 30, 1000, 5000, 10_001, 0, true);
 
     abort
 }

--- a/packages/dapp/contracts/prop-amm/tests/executor_tests.move
+++ b/packages/dapp/contracts/prop-amm/tests/executor_tests.move
@@ -126,6 +126,7 @@ fun create_executor_for_pool(
         1000,
         5000,
         0,
+        0,
         true,
     );
     // Restore the native tx sender after `tx_context::dummy()` inside the `create_*_currency`
@@ -250,8 +251,8 @@ fun create_executor_creates_distinct_accounts_and_caps() {
     );
     destroy(sui_currency);
     destroy(usdc_currency);
-    let amm_config_a = config::new(100, 200, 30_000, 30, 1000, 5000, 0, true);
-    let amm_config_b = config::new(125, 250, 30_000, 30, 1000, 5000, 0, true);
+    let amm_config_a = config::new(100, 200, 30_000, 30, 1000, 5000, 0, 0, true);
+    let amm_config_b = config::new(125, 250, 30_000, 30, 1000, 5000, 0, 0, true);
 
     scenario.next_tx(sender);
 
@@ -305,7 +306,7 @@ fun create_returns_paused_executor() {
     );
     destroy(sui_currency);
     destroy(usdc_currency);
-    let amm_config = config::new(100, 200, 30_000, 30, 1000, 5000, 0, true);
+    let amm_config = config::new(100, 200, 30_000, 30, 1000, 5000, 0, 0, true);
     scenario.next_tx(sender);
 
     let (executor_object, executor_cap) = executor::create(
@@ -591,6 +592,7 @@ fun update_config_replaces_config_before_refreshing_quotes() {
         1000,
         5000,
         0,
+        0,
         true,
     );
     executor_object.update_config(&executor_cap, updated_config);
@@ -753,7 +755,7 @@ fun update_config_preserves_paused_state() {
     executor_object.pause(&executor_cap, &mut pool, &clock, scenario.ctx());
     assert_emitted!(executor_paused(executor_object.id()));
 
-    let updated_config = config::new(120, 240, 30_000, 30, 1000, 5000, 0, true);
+    let updated_config = config::new(120, 240, 30_000, 30, 1000, 5000, 0, 0, true);
     executor_object.update_config(&executor_cap, updated_config);
 
     assert_emitted!(executor_config_updated(executor_object.id()));
@@ -798,6 +800,7 @@ fun update_config_rejects_when_unchanged() {
         30,
         1000,
         5000,
+        0,
         0,
         true,
     );

--- a/packages/dapp/src/scripts/owner/amm-create.ts
+++ b/packages/dapp/src/scripts/owner/amm-create.ts
@@ -316,7 +316,7 @@ runSuiScript(
       alias: ["stale-price-tolerance-bps"],
       type: "string",
       description:
-        "Permissionless-refresh skip threshold in basis points of price; 0 disables the guard (u64). Bounded on-chain by --base-spread-bps.",
+        "Permissionless-refresh skip threshold in basis points [0..10000), expressed as a fraction of base_spread (u64). 0 disables the guard. E.g. with base-spread-bps=100, 5000 tolerates 50 bps of price drift.",
       default: DEFAULT_STALE_PRICE_TOLERANCE_BPS,
       demandOption: false
     })

--- a/packages/dapp/src/scripts/owner/amm-create.ts
+++ b/packages/dapp/src/scripts/owner/amm-create.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_ORDER_EXPIRATION_TIME_MS,
   DEFAULT_OUTER_BALANCE_BPS,
   DEFAULT_POST_ONLY,
+  DEFAULT_STALE_PRICE_TOLERANCE_BPS,
   DEFAULT_VOLATILITY_MULTIPLIER_BPS,
   getAmmConfigOverview,
   resolveAmmConfigInputs
@@ -46,6 +47,7 @@ type CreateAmmArguments = {
   maxConfRatioBps?: string
   outerBalanceBps?: string
   inventorySkewBps?: string
+  stalePriceToleranceBps?: string
   postOnly?: string
   ammPackageId?: string
   devInspect?: boolean
@@ -104,6 +106,7 @@ runSuiScript(
       maxConfRatioBps: cliArguments.maxConfRatioBps,
       outerBalanceBps: cliArguments.outerBalanceBps,
       inventorySkewBps: cliArguments.inventorySkewBps,
+      stalePriceToleranceBps: cliArguments.stalePriceToleranceBps,
       postOnly: cliArguments.postOnly
     })
 
@@ -152,6 +155,7 @@ runSuiScript(
       maxConfRatioBps: ammConfigInputs.maxConfRatioBps,
       outerBalanceBps: ammConfigInputs.outerBalanceBps,
       inventorySkewBps: ammConfigInputs.inventorySkewBps,
+      stalePriceToleranceBps: ammConfigInputs.stalePriceToleranceBps,
       postOnly: ammConfigInputs.postOnly
     })
 
@@ -306,6 +310,14 @@ runSuiScript(
       description:
         "Inventory-driven mid-shift coefficient in basis points; 0 disables skewing (u64).",
       default: DEFAULT_INVENTORY_SKEW_BPS,
+      demandOption: false
+    })
+    .option("stalePriceToleranceBps", {
+      alias: ["stale-price-tolerance-bps"],
+      type: "string",
+      description:
+        "Permissionless-refresh skip threshold in basis points of price; 0 disables the guard (u64). Bounded on-chain by --base-spread-bps.",
+      default: DEFAULT_STALE_PRICE_TOLERANCE_BPS,
       demandOption: false
     })
     .option("postOnly", {

--- a/packages/dapp/src/scripts/owner/amm-update.ts
+++ b/packages/dapp/src/scripts/owner/amm-update.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_MAX_PRICE_AGE_SECS,
   DEFAULT_ORDER_EXPIRATION_TIME_MS,
   DEFAULT_OUTER_BALANCE_BPS,
+  DEFAULT_STALE_PRICE_TOLERANCE_BPS,
   type AmmConfigOverview,
   getAmmConfigOverview,
   resolveAmmConfigInputs
@@ -42,6 +43,7 @@ type UpdateAmmArguments = {
   maxConfRatioBps?: string
   outerBalanceBps?: string
   inventorySkewBps?: string
+  stalePriceToleranceBps?: string
   postOnly?: string
   devInspect?: boolean
   dryRun?: boolean
@@ -56,6 +58,7 @@ type ResolvedAmmUpdateInputs = {
   maxConfRatioBps: bigint
   outerBalanceBps: bigint
   inventorySkewBps: bigint
+  stalePriceToleranceBps: bigint
   postOnly: boolean
 }
 
@@ -116,6 +119,9 @@ const resolveAmmUpdateInputs = ({
       cliArguments.outerBalanceBps ?? currentOverview.outerBalanceBps,
     inventorySkewBps:
       cliArguments.inventorySkewBps ?? currentOverview.inventorySkewBps,
+    stalePriceToleranceBps:
+      cliArguments.stalePriceToleranceBps ??
+      currentOverview.stalePriceToleranceBps,
     postOnly: cliArguments.postOnly ?? String(currentOverview.postOnly)
   })
 
@@ -127,6 +133,7 @@ const resolveAmmUpdateInputs = ({
     maxConfRatioBps: inputs.maxConfRatioBps,
     outerBalanceBps: inputs.outerBalanceBps,
     inventorySkewBps: inputs.inventorySkewBps,
+    stalePriceToleranceBps: inputs.stalePriceToleranceBps,
     postOnly: inputs.postOnly
   }
 }
@@ -168,6 +175,7 @@ runSuiScript(
       maxConfRatioBps: updateInputs.maxConfRatioBps,
       outerBalanceBps: updateInputs.outerBalanceBps,
       inventorySkewBps: updateInputs.inventorySkewBps,
+      stalePriceToleranceBps: updateInputs.stalePriceToleranceBps,
       postOnly: updateInputs.postOnly
     })
 
@@ -280,6 +288,14 @@ runSuiScript(
       description:
         "Inventory-driven mid-shift coefficient in basis points (u64); defaults to the current config value.",
       default: DEFAULT_INVENTORY_SKEW_BPS,
+      demandOption: false
+    })
+    .option("stalePriceToleranceBps", {
+      alias: ["stale-price-tolerance-bps"],
+      type: "string",
+      description:
+        "Permissionless-refresh skip threshold in basis points of price (u64); 0 disables the guard. Bounded on-chain by base-spread-bps. Defaults to the current config value.",
+      default: DEFAULT_STALE_PRICE_TOLERANCE_BPS,
       demandOption: false
     })
     .option("postOnly", {

--- a/packages/dapp/src/scripts/owner/amm-update.ts
+++ b/packages/dapp/src/scripts/owner/amm-update.ts
@@ -294,7 +294,7 @@ runSuiScript(
       alias: ["stale-price-tolerance-bps"],
       type: "string",
       description:
-        "Permissionless-refresh skip threshold in basis points of price (u64); 0 disables the guard. Bounded on-chain by base-spread-bps. Defaults to the current config value.",
+        "Permissionless-refresh skip threshold in basis points [0..10000), expressed as a fraction of base_spread (u64); 0 disables the guard. E.g. with base-spread-bps=100, 5000 tolerates 50 bps of price drift. Defaults to the current config value.",
       default: DEFAULT_STALE_PRICE_TOLERANCE_BPS,
       demandOption: false
     })

--- a/packages/dapp/src/scripts/owner/amm-update.ts
+++ b/packages/dapp/src/scripts/owner/amm-update.ts
@@ -8,12 +8,6 @@
 import yargs from "yargs"
 
 import {
-  DEFAULT_INVENTORY_SKEW_BPS,
-  DEFAULT_MAX_CONF_RATIO_BPS,
-  DEFAULT_MAX_PRICE_AGE_SECS,
-  DEFAULT_ORDER_EXPIRATION_TIME_MS,
-  DEFAULT_OUTER_BALANCE_BPS,
-  DEFAULT_STALE_PRICE_TOLERANCE_BPS,
   type AmmConfigOverview,
   getAmmConfigOverview,
   resolveAmmConfigInputs
@@ -255,7 +249,6 @@ runSuiScript(
       type: "string",
       description:
         "Order expiration duration in milliseconds (u64); defaults to the current config value.",
-      default: DEFAULT_ORDER_EXPIRATION_TIME_MS,
       demandOption: false
     })
     .option("maxPriceAgeSecs", {
@@ -263,7 +256,6 @@ runSuiScript(
       type: "string",
       description:
         "Maximum acceptable Pyth price age in seconds (u64); defaults to the current config value.",
-      default: DEFAULT_MAX_PRICE_AGE_SECS,
       demandOption: false
     })
     .option("maxConfRatioBps", {
@@ -271,7 +263,6 @@ runSuiScript(
       type: "string",
       description:
         "Maximum acceptable confidence-to-price ratio in basis points (u64); defaults to the current config value.",
-      default: DEFAULT_MAX_CONF_RATIO_BPS,
       demandOption: false
     })
     .option("outerBalanceBps", {
@@ -279,7 +270,6 @@ runSuiScript(
       type: "string",
       description:
         "Share of the settleable balance allocated to the outer (volatility) spread order in basis points (u64); defaults to the current config value.",
-      default: DEFAULT_OUTER_BALANCE_BPS,
       demandOption: false
     })
     .option("inventorySkewBps", {
@@ -287,7 +277,6 @@ runSuiScript(
       type: "string",
       description:
         "Inventory-driven mid-shift coefficient in basis points (u64); defaults to the current config value.",
-      default: DEFAULT_INVENTORY_SKEW_BPS,
       demandOption: false
     })
     .option("stalePriceToleranceBps", {
@@ -295,7 +284,6 @@ runSuiScript(
       type: "string",
       description:
         "Permissionless-refresh skip threshold in basis points [0..10000), expressed as a fraction of base_spread (u64); 0 disables the guard. E.g. with base-spread-bps=100, 5000 tolerates 50 bps of price drift. Defaults to the current config value.",
-      default: DEFAULT_STALE_PRICE_TOLERANCE_BPS,
       demandOption: false
     })
     .option("postOnly", {

--- a/packages/dapp/src/utils/amm.ts
+++ b/packages/dapp/src/utils/amm.ts
@@ -234,6 +234,7 @@ export const logAmmConfigOverview = (
   logKeyValueGreen("Max-conf-bps")(overview.maxConfRatioBps)
   logKeyValueGreen("Outer-balance-bps")(overview.outerBalanceBps)
   logKeyValueGreen("Inv-skew-bps")(overview.inventorySkewBps)
+  logKeyValueGreen("Stale-tol-bps")(overview.stalePriceToleranceBps)
   if (options?.initialSharedVersion) {
     logKeyValueGreen("Shared-ver")(options.initialSharedVersion)
   }

--- a/packages/dapp/src/utils/test/amm-ptb.test.ts
+++ b/packages/dapp/src/utils/test/amm-ptb.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it } from "vitest"
 
+import { bcs } from "@mysten/sui/bcs"
+import { fromBase64 } from "@mysten/sui/utils"
 import {
   buildCreateExecutorTransaction,
   buildUpdateConfigTransaction
 } from "@sui-amm/domain-core/ptb/amm"
 import type { WrappedSuiSharedObject } from "@sui-amm/tooling-core/shared-object"
 
-const expectMoveCall = (
-  command: ReturnType<
-    ReturnType<typeof buildCreateExecutorTransaction>["getData"]
-  >["commands"][number]
-) => {
+type TxData = ReturnType<
+  ReturnType<typeof buildCreateExecutorTransaction>["getData"]
+>
+type TxInputs = TxData["inputs"]
+type MoveCallArgs = NonNullable<
+  Extract<TxData["commands"][number], { $kind: "MoveCall" }>["MoveCall"]
+>["arguments"]
+
+const expectMoveCall = (command: TxData["commands"][number]) => {
   expect(command.$kind).toBe("MoveCall")
   if (command.$kind !== "MoveCall") {
     throw new Error("Expected MoveCall command.")
@@ -18,6 +24,38 @@ const expectMoveCall = (
 
   return command.MoveCall
 }
+
+const resolvePureBytes = (
+  inputs: TxInputs,
+  args: MoveCallArgs,
+  argIndex: number
+): Uint8Array => {
+  const arg = args[argIndex]
+  expect(arg.$kind).toBe("Input")
+  if (arg.$kind !== "Input") {
+    throw new Error(`Expected Input at arg index ${argIndex}.`)
+  }
+  const input = inputs[arg.Input]
+  expect(input.$kind).toBe("Pure")
+  if (input.$kind !== "Pure") {
+    throw new Error(`Expected Pure input for arg index ${argIndex}.`)
+  }
+  return fromBase64(input.Pure.bytes)
+}
+
+// `bcs.u64().parse` returns a string representation of the u64 (numbers can't
+// safely represent the full u64 range). Tests compare via string equality.
+const decodePureU64 = (
+  inputs: TxInputs,
+  args: MoveCallArgs,
+  argIndex: number
+): string => bcs.u64().parse(resolvePureBytes(inputs, args, argIndex))
+
+const decodePureBool = (
+  inputs: TxInputs,
+  args: MoveCallArgs,
+  argIndex: number
+): boolean => bcs.bool().parse(resolvePureBytes(inputs, args, argIndex))
 
 const FEED_BYTES = Array.from({ length: 32 }, (_, index) => index)
 
@@ -80,6 +118,18 @@ const QUOTE_CURRENCY: WrappedSuiSharedObject = {
 
 describe("amm PTB builders", () => {
   it("builds create with market::new + config::new + executor::create + share + transfer", () => {
+    // Unique per-arg values so any positional swap in `config::new` is caught
+    // by the per-position assertions below.
+    const baseSpreadBps = 25n
+    const volatilityMultiplierBps = 12_345n
+    const orderExpirationTimeMs = 86_400_001n
+    const maxPriceAgeSecs = 31n
+    const maxConfRatioBps = 1_001n
+    const outerBalanceBps = 5_001n
+    const inventorySkewBps = 100n
+    const stalePriceToleranceBps = 7_000n
+    const postOnly = true
+
     const transaction = buildCreateExecutorTransaction({
       packageId: "0x123",
       pool: POOL,
@@ -88,17 +138,17 @@ describe("amm PTB builders", () => {
       baseAssetTypeTag: BASE_ASSET_TYPE_TAG,
       quoteAssetTypeTag: QUOTE_ASSET_TYPE_TAG,
       senderAddress: "0x789",
-      baseSpreadBps: 25n,
-      volatilityMultiplierBps: 10000n,
+      baseSpreadBps,
+      volatilityMultiplierBps,
       basePythPriceFeedIdBytes: FEED_BYTES,
       quotePythPriceFeedIdBytes: FEED_BYTES,
-      orderExpirationTimeMs: 86400000n,
-      maxPriceAgeSecs: 60n,
-      maxConfRatioBps: 1000n,
-      outerBalanceBps: 5000n,
-      inventorySkewBps: 0n,
-      stalePriceToleranceBps: 0n,
-      postOnly: true
+      orderExpirationTimeMs,
+      maxPriceAgeSecs,
+      maxConfRatioBps,
+      outerBalanceBps,
+      inventorySkewBps,
+      stalePriceToleranceBps,
+      postOnly
     })
 
     const transactionData = transaction.getData()
@@ -123,6 +173,37 @@ describe("amm PTB builders", () => {
       module: "config",
       function: "new"
     })
+
+    // Guard the positional encoding of `config::new` arguments: a dropped or
+    // reordered field would either change the count or shift a unique value
+    // to a neighboring slot, failing one of these checks.
+    const configArgs = configCall.arguments
+    expect(configArgs).toHaveLength(9)
+    expect(decodePureU64(transactionData.inputs, configArgs, 0)).toBe(
+      baseSpreadBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 1)).toBe(
+      volatilityMultiplierBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 2)).toBe(
+      orderExpirationTimeMs.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 3)).toBe(
+      maxPriceAgeSecs.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 4)).toBe(
+      maxConfRatioBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 5)).toBe(
+      outerBalanceBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 6)).toBe(
+      inventorySkewBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 7)).toBe(
+      stalePriceToleranceBps.toString()
+    )
+    expect(decodePureBool(transactionData.inputs, configArgs, 8)).toBe(postOnly)
 
     const createCall = expectMoveCall(transactionData.commands[2])
     expect(createCall).toMatchObject({
@@ -171,19 +252,30 @@ describe("amm PTB builders", () => {
   })
 
   it("builds update config with config::new + executor::update_config", () => {
+    // Unique per-arg values — same regression-catching rationale as the create test.
+    const baseSpreadBps = 26n
+    const volatilityMultiplierBps = 12_346n
+    const orderExpirationTimeMs = 86_400_002n
+    const maxPriceAgeSecs = 32n
+    const maxConfRatioBps = 1_002n
+    const outerBalanceBps = 5_002n
+    const inventorySkewBps = 101n
+    const stalePriceToleranceBps = 7_001n
+    const postOnly = true
+
     const transaction = buildUpdateConfigTransaction({
       packageId: "0x123",
       executor: EXECUTOR,
       adminCapId: "0x456",
-      baseSpreadBps: 25n,
-      volatilityMultiplierBps: 10000n,
-      orderExpirationTimeMs: 86400000n,
-      maxPriceAgeSecs: 60n,
-      maxConfRatioBps: 1000n,
-      outerBalanceBps: 5000n,
-      inventorySkewBps: 0n,
-      stalePriceToleranceBps: 0n,
-      postOnly: true
+      baseSpreadBps,
+      volatilityMultiplierBps,
+      orderExpirationTimeMs,
+      maxPriceAgeSecs,
+      maxConfRatioBps,
+      outerBalanceBps,
+      inventorySkewBps,
+      stalePriceToleranceBps,
+      postOnly
     })
 
     const transactionData = transaction.getData()
@@ -196,6 +288,35 @@ describe("amm PTB builders", () => {
       module: "config",
       function: "new"
     })
+
+    // Guard the positional encoding of `config::new` arguments.
+    const configArgs = configCall.arguments
+    expect(configArgs).toHaveLength(9)
+    expect(decodePureU64(transactionData.inputs, configArgs, 0)).toBe(
+      baseSpreadBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 1)).toBe(
+      volatilityMultiplierBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 2)).toBe(
+      orderExpirationTimeMs.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 3)).toBe(
+      maxPriceAgeSecs.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 4)).toBe(
+      maxConfRatioBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 5)).toBe(
+      outerBalanceBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 6)).toBe(
+      inventorySkewBps.toString()
+    )
+    expect(decodePureU64(transactionData.inputs, configArgs, 7)).toBe(
+      stalePriceToleranceBps.toString()
+    )
+    expect(decodePureBool(transactionData.inputs, configArgs, 8)).toBe(postOnly)
 
     const updateCall = expectMoveCall(transactionData.commands[1])
     expect(updateCall).toMatchObject({

--- a/packages/dapp/src/utils/test/amm-ptb.test.ts
+++ b/packages/dapp/src/utils/test/amm-ptb.test.ts
@@ -97,6 +97,7 @@ describe("amm PTB builders", () => {
       maxConfRatioBps: 1000n,
       outerBalanceBps: 5000n,
       inventorySkewBps: 0n,
+      stalePriceToleranceBps: 0n,
       postOnly: true
     })
 
@@ -161,6 +162,7 @@ describe("amm PTB builders", () => {
         maxConfRatioBps: 1000n,
         outerBalanceBps: 5000n,
         inventorySkewBps: 0n,
+        stalePriceToleranceBps: 0n,
         postOnly: true
       })
     ).toThrowError(
@@ -180,6 +182,7 @@ describe("amm PTB builders", () => {
       maxConfRatioBps: 1000n,
       outerBalanceBps: 5000n,
       inventorySkewBps: 0n,
+      stalePriceToleranceBps: 0n,
       postOnly: true
     })
 

--- a/packages/domain/core/src/models/amm.ts
+++ b/packages/domain/core/src/models/amm.ts
@@ -25,7 +25,7 @@ export const DEFAULT_MAX_CONF_RATIO_BPS = "1000"
 export const DEFAULT_OUTER_BALANCE_BPS = "5000"
 export const DEFAULT_INVENTORY_SKEW_BPS = "0"
 // Disabled by default: every Pyth tick triggers a refresh (original behavior).
-// Move-side constraint is `stale_price_tolerance_bps <= base_spread_bps`.
+// Move-side constraint is `stale_price_tolerance_bps < 10_000` (fraction of `base_spread_bps`).
 export const DEFAULT_STALE_PRICE_TOLERANCE_BPS = "0"
 export const DEFAULT_POST_ONLY = "true"
 

--- a/packages/domain/core/src/models/amm.ts
+++ b/packages/domain/core/src/models/amm.ts
@@ -24,6 +24,9 @@ export const DEFAULT_MAX_PRICE_AGE_SECS = "60"
 export const DEFAULT_MAX_CONF_RATIO_BPS = "1000"
 export const DEFAULT_OUTER_BALANCE_BPS = "5000"
 export const DEFAULT_INVENTORY_SKEW_BPS = "0"
+// Disabled by default: every Pyth tick triggers a refresh (original behavior).
+// Move-side constraint is `stale_price_tolerance_bps <= base_spread_bps`.
+export const DEFAULT_STALE_PRICE_TOLERANCE_BPS = "0"
 export const DEFAULT_POST_ONLY = "true"
 
 export type AmmConfigOverview = {
@@ -39,6 +42,7 @@ export type AmmConfigOverview = {
   maxConfRatioBps: string
   outerBalanceBps: string
   inventorySkewBps: string
+  stalePriceToleranceBps: string
   postOnly: boolean
 }
 
@@ -50,6 +54,7 @@ type AmmConfigFields = {
   max_conf_ratio_bps?: unknown
   outer_balance_bps?: unknown
   inventory_skew_bps?: unknown
+  stale_price_tolerance_bps?: unknown
   post_only?: unknown
 }
 
@@ -156,6 +161,10 @@ const buildAmmConfigOverviewFromObject = ({
       config.inventory_skew_bps,
       "Inventory skew bps"
     ),
+    stalePriceToleranceBps: requireNumericField(
+      config.stale_price_tolerance_bps,
+      "Stale price tolerance bps"
+    ),
     postOnly: requireBooleanField(config.post_only, "Post only")
   }
 }
@@ -211,6 +220,7 @@ export const resolveAmmConfigInputs = ({
   maxConfRatioBps,
   outerBalanceBps,
   inventorySkewBps,
+  stalePriceToleranceBps,
   postOnly
 }: {
   volatilityMultiplierBps?: string
@@ -222,6 +232,7 @@ export const resolveAmmConfigInputs = ({
   maxConfRatioBps?: string
   outerBalanceBps?: string
   inventorySkewBps?: string
+  stalePriceToleranceBps?: string
   postOnly?: string
 }): {
   baseSpreadBps: bigint
@@ -235,6 +246,7 @@ export const resolveAmmConfigInputs = ({
   maxConfRatioBps: bigint
   outerBalanceBps: bigint
   inventorySkewBps: bigint
+  stalePriceToleranceBps: bigint
   postOnly: boolean
 } => ({
   baseSpreadBps: resolveBaseSpreadBps(baseSpreadBps),
@@ -264,6 +276,10 @@ export const resolveAmmConfigInputs = ({
   inventorySkewBps: parseNonNegativeU64(
     inventorySkewBps ?? DEFAULT_INVENTORY_SKEW_BPS,
     "Inventory skew bps"
+  ),
+  stalePriceToleranceBps: parseNonNegativeU64(
+    stalePriceToleranceBps ?? DEFAULT_STALE_PRICE_TOLERANCE_BPS,
+    "Stale price tolerance bps"
   ),
   postOnly: parseBooleanFlag(postOnly ?? DEFAULT_POST_ONLY, "Post only")
 })

--- a/packages/domain/core/src/ptb/amm.ts
+++ b/packages/domain/core/src/ptb/amm.ts
@@ -71,9 +71,10 @@ export const buildCreateExecutorTransaction = ({
   outerBalanceBps: bigint | number
   inventorySkewBps: bigint | number
   /**
-   * Permissionless-refresh skip threshold in bps of price. `0` disables the
-   * guard (every Pyth tick triggers a refresh). Bounded on-chain by
-   * `base_spread_bps`.
+   * Permissionless-refresh skip threshold in basis points [0..10_000), expressed as a
+   * fraction of `base_spread`. `0` disables the guard (every Pyth tick triggers a
+   * refresh). E.g. with `baseSpreadBps = 100`, `5_000` tolerates 50 bps of price
+   * drift before refreshing.
    */
   stalePriceToleranceBps: bigint | number
   /**
@@ -167,9 +168,10 @@ export const buildUpdateConfigTransaction = ({
   outerBalanceBps: bigint | number
   inventorySkewBps: bigint | number
   /**
-   * Permissionless-refresh skip threshold in bps of price. `0` disables the
-   * guard (every Pyth tick triggers a refresh). Bounded on-chain by
-   * `base_spread_bps`.
+   * Permissionless-refresh skip threshold in basis points [0..10_000), expressed as a
+   * fraction of `base_spread`. `0` disables the guard (every Pyth tick triggers a
+   * refresh). E.g. with `baseSpreadBps = 100`, `5_000` tolerates 50 bps of price
+   * drift before refreshing.
    */
   stalePriceToleranceBps: bigint | number
   /**

--- a/packages/domain/core/src/ptb/amm.ts
+++ b/packages/domain/core/src/ptb/amm.ts
@@ -51,6 +51,7 @@ export const buildCreateExecutorTransaction = ({
   maxConfRatioBps,
   outerBalanceBps,
   inventorySkewBps,
+  stalePriceToleranceBps,
   postOnly
 }: {
   packageId: string
@@ -69,6 +70,12 @@ export const buildCreateExecutorTransaction = ({
   maxConfRatioBps: bigint | number
   outerBalanceBps: bigint | number
   inventorySkewBps: bigint | number
+  /**
+   * Permissionless-refresh skip threshold in bps of price. `0` disables the
+   * guard (every Pyth tick triggers a refresh). Bounded on-chain by
+   * `base_spread_bps`.
+   */
+  stalePriceToleranceBps: bigint | number
   /**
    * When true, `refresh_quotes` places each order with DeepBook's `post_only` flag —
    * any order that would cross the resting book aborts the whole refresh and the
@@ -111,6 +118,7 @@ export const buildCreateExecutorTransaction = ({
       transaction.pure.u64(maxConfRatioBps),
       transaction.pure.u64(outerBalanceBps),
       transaction.pure.u64(inventorySkewBps),
+      transaction.pure.u64(stalePriceToleranceBps),
       transaction.pure.bool(postOnly)
     ]
   })
@@ -145,6 +153,7 @@ export const buildUpdateConfigTransaction = ({
   maxConfRatioBps,
   outerBalanceBps,
   inventorySkewBps,
+  stalePriceToleranceBps,
   postOnly
 }: {
   packageId: string
@@ -157,6 +166,12 @@ export const buildUpdateConfigTransaction = ({
   maxConfRatioBps: bigint | number
   outerBalanceBps: bigint | number
   inventorySkewBps: bigint | number
+  /**
+   * Permissionless-refresh skip threshold in bps of price. `0` disables the
+   * guard (every Pyth tick triggers a refresh). Bounded on-chain by
+   * `base_spread_bps`.
+   */
+  stalePriceToleranceBps: bigint | number
   /**
    * When true, `refresh_quotes` places each order with DeepBook's `post_only` flag —
    * any order that would cross the resting book aborts the whole refresh and the
@@ -177,6 +192,7 @@ export const buildUpdateConfigTransaction = ({
       transaction.pure.u64(maxConfRatioBps),
       transaction.pure.u64(outerBalanceBps),
       transaction.pure.u64(inventorySkewBps),
+      transaction.pure.u64(stalePriceToleranceBps),
       transaction.pure.bool(postOnly)
     ]
   })

--- a/packages/domain/node/src/amm.ts
+++ b/packages/domain/node/src/amm.ts
@@ -285,6 +285,7 @@ export const createAmmConfigSnapshot = async ({
     maxConfRatioBps: ammConfigInputs.maxConfRatioBps,
     outerBalanceBps: ammConfigInputs.outerBalanceBps,
     inventorySkewBps: ammConfigInputs.inventorySkewBps,
+    stalePriceToleranceBps: ammConfigInputs.stalePriceToleranceBps,
     postOnly: ammConfigInputs.postOnly
   })
 
@@ -333,6 +334,7 @@ export const createAmmConfigSnapshotFromArgs = async ({
   maxConfRatioBps,
   outerBalanceBps,
   inventorySkewBps,
+  stalePriceToleranceBps,
   postOnly
 }: {
   tooling: Tooling
@@ -347,6 +349,7 @@ export const createAmmConfigSnapshotFromArgs = async ({
   maxConfRatioBps?: string
   outerBalanceBps?: string
   inventorySkewBps?: string
+  stalePriceToleranceBps?: string
   postOnly?: string
 }): Promise<{
   ammConfigSnapshot: AmmConfigSnapshot
@@ -365,6 +368,7 @@ export const createAmmConfigSnapshotFromArgs = async ({
     maxConfRatioBps,
     outerBalanceBps,
     inventorySkewBps,
+    stalePriceToleranceBps,
     postOnly
   })
 

--- a/packages/ui/next-env.d.ts
+++ b/packages/ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/dev/types/routes.d.ts"
+import "./dist/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/ui/next-env.d.ts
+++ b/packages/ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/dev/types/routes.d.ts";
+import "./dist/dev/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/ui/src/app/components/AmmConfigForm.tsx
+++ b/packages/ui/src/app/components/AmmConfigForm.tsx
@@ -17,6 +17,7 @@ export type AmmConfigFormState = {
   maxConfRatioBps: string
   outerBalanceBps: string
   inventorySkewBps: string
+  stalePriceToleranceBps: string
   postOnly: string
 }
 
@@ -148,6 +149,21 @@ const GROUPS: GroupSpec[] = [
         title: "Max Pyth price age (s)",
         description: "Reject oracle reads older than this many seconds.",
         placeholder: "60"
+      }
+    ]
+  },
+  {
+    title: "Refresh Throttling",
+    description:
+      "Skip a permissionless refresh when the new oracle inputs would barely move the resting ladder, to preserve FIFO priority on DeepBook.",
+    fields: [
+      {
+        kind: "bps",
+        key: "stalePriceToleranceBps",
+        title: "Stale price tolerance",
+        description:
+          "Skip refresh when the worst-case ladder drift is below this fraction of price. 0 disables the guard. Bounded by Base spread.",
+        sliderMaxBps: SLIDER_MAX_BOUNDED_BPS
       }
     ]
   },

--- a/packages/ui/src/app/components/AmmConfigForm.tsx
+++ b/packages/ui/src/app/components/AmmConfigForm.tsx
@@ -153,25 +153,18 @@ const GROUPS: GroupSpec[] = [
     ]
   },
   {
-    title: "Refresh Throttling",
+    title: "Safety",
     description:
-      "Skip a permissionless refresh when the new oracle inputs would barely move the resting ladder, to preserve FIFO priority on DeepBook.",
+      "How refresh_quotes places its orders relative to the resting book, and when a permissionless refresh is allowed to skip.",
     fields: [
       {
         kind: "bps",
         key: "stalePriceToleranceBps",
         title: "Stale price tolerance",
         description:
-          "Skip refresh when the worst-case ladder drift is below this fraction of price. 0 disables the guard. Bounded by Base spread.",
+          "Fraction of Base spread the ladder is allowed to drift before a permissionless refresh proceeds. 0 disables the guard. E.g. at base spread 100 bps, 50 % tolerates 50 bps of price drift before re-quoting.",
         sliderMaxBps: SLIDER_MAX_BOUNDED_BPS
-      }
-    ]
-  },
-  {
-    title: "Safety",
-    description:
-      "How refresh_quotes places its orders relative to the resting book.",
-    fields: [
+      },
       {
         kind: "toggle",
         key: "postOnly",

--- a/packages/ui/src/app/helpers/ammConfigValidation.ts
+++ b/packages/ui/src/app/helpers/ammConfigValidation.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_ORDER_EXPIRATION_TIME_MS,
   DEFAULT_OUTER_BALANCE_BPS,
   DEFAULT_POST_ONLY,
+  DEFAULT_STALE_PRICE_TOLERANCE_BPS,
   DEFAULT_VOLATILITY_MULTIPLIER_BPS
 } from "@sui-amm/domain-core/models/amm"
 import {
@@ -76,6 +77,13 @@ const FIELD_VALIDATORS: Partial<Record<AmmConfigFieldKey, FieldValidator>> = {
     parse: parseNonNegativeU64,
     label: "Inventory skew bps",
     maxExclusiveBps: true
+  },
+  stalePriceToleranceBps: {
+    required: "Stale price tolerance is required.",
+    fallbackMessage: "Stale price tolerance must be a valid u64.",
+    parse: parseNonNegativeU64,
+    label: "Stale price tolerance bps",
+    maxExclusiveBps: true
   }
 }
 
@@ -93,6 +101,8 @@ export const buildAmmConfigFormState = (
   maxConfRatioBps: ammConfig?.maxConfRatioBps ?? DEFAULT_MAX_CONF_RATIO_BPS,
   outerBalanceBps: ammConfig?.outerBalanceBps ?? DEFAULT_OUTER_BALANCE_BPS,
   inventorySkewBps: ammConfig?.inventorySkewBps ?? DEFAULT_INVENTORY_SKEW_BPS,
+  stalePriceToleranceBps:
+    ammConfig?.stalePriceToleranceBps ?? DEFAULT_STALE_PRICE_TOLERANCE_BPS,
   postOnly:
     ammConfig?.postOnly !== undefined
       ? String(ammConfig.postOnly)

--- a/packages/ui/src/app/hooks/useCreateExecutorState.ts
+++ b/packages/ui/src/app/hooks/useCreateExecutorState.ts
@@ -402,6 +402,7 @@ export const useCreateExecutorState = () => {
         maxConfRatioBps: ammFormState.maxConfRatioBps.trim(),
         outerBalanceBps: ammFormState.outerBalanceBps.trim(),
         inventorySkewBps: ammFormState.inventorySkewBps.trim(),
+        stalePriceToleranceBps: ammFormState.stalePriceToleranceBps.trim(),
         postOnly: ammFormState.postOnly.trim()
       })
 
@@ -422,6 +423,7 @@ export const useCreateExecutorState = () => {
         maxConfRatioBps: inputs.maxConfRatioBps,
         outerBalanceBps: inputs.outerBalanceBps,
         inventorySkewBps: inputs.inventorySkewBps,
+        stalePriceToleranceBps: inputs.stalePriceToleranceBps,
         postOnly: inputs.postOnly
       })
       createTransaction.setSender(walletAddress)

--- a/packages/ui/src/app/hooks/useUpdateAmmConfigModalState.ts
+++ b/packages/ui/src/app/hooks/useUpdateAmmConfigModalState.ts
@@ -82,6 +82,7 @@ const buildOptimisticOverview = ({
   maxConfRatioBps: formState.maxConfRatioBps.trim(),
   outerBalanceBps: formState.outerBalanceBps.trim(),
   inventorySkewBps: formState.inventorySkewBps.trim(),
+  stalePriceToleranceBps: formState.stalePriceToleranceBps.trim(),
   postOnly: formState.postOnly.trim().toLowerCase() === "true"
 })
 
@@ -96,6 +97,7 @@ const ammConfigMatches = (
   first.maxConfRatioBps === second.maxConfRatioBps &&
   first.outerBalanceBps === second.outerBalanceBps &&
   first.inventorySkewBps === second.inventorySkewBps &&
+  first.stalePriceToleranceBps === second.stalePriceToleranceBps &&
   first.postOnly === second.postOnly &&
   first.active === second.active
 
@@ -286,6 +288,7 @@ export const useUpdateAmmConfigModalState = ({
         maxConfRatioBps: formState.maxConfRatioBps.trim(),
         outerBalanceBps: formState.outerBalanceBps.trim(),
         inventorySkewBps: formState.inventorySkewBps.trim(),
+        stalePriceToleranceBps: formState.stalePriceToleranceBps.trim(),
         postOnly: formState.postOnly.trim()
       })
 
@@ -318,6 +321,7 @@ export const useUpdateAmmConfigModalState = ({
         maxConfRatioBps: updateInputs.maxConfRatioBps,
         outerBalanceBps: updateInputs.outerBalanceBps,
         inventorySkewBps: updateInputs.inventorySkewBps,
+        stalePriceToleranceBps: updateInputs.stalePriceToleranceBps,
         postOnly: updateInputs.postOnly
       })
       updateTransaction.setSender(walletAddress)

--- a/packages/ui/src/app/providers/ClientProviders.tsx
+++ b/packages/ui/src/app/providers/ClientProviders.tsx
@@ -3,10 +3,11 @@
 import "@mysten/dapp-kit/dist/index.css"
 import "@radix-ui/themes/styles.css"
 import "@suiware/kit/main.css"
-import SuiProvider from "@suiware/kit/SuiProvider"
+import { SuiClientProvider, WalletProvider } from "@mysten/dapp-kit"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ENetwork } from "@sui-amm/tooling-core/types"
 import { ThemeProvider as NextThemeProvider } from "next-themes"
-import { Suspense, type ReactNode } from "react"
+import { Suspense, useMemo, useState, type ReactNode } from "react"
 import useNetworkConfig from "~~/hooks/useNetworkConfig"
 import { APP_NAME } from "../config/main"
 import { getThemeSettings } from "../helpers/theme"
@@ -17,33 +18,76 @@ import WalletAccountGuard from "./WalletAccountGuard"
 
 const themeSettings = getThemeSettings()
 
+// Slush wallet uses `metadata.walletName === "Slush"` regardless of the `name`
+// passed to `registerSlushWallet`, so this is a stable identifier.
+const SLUSH_WALLET_NAME = "Slush"
+
+// Default dapp-kit persistence key for last-connected wallet info.
+const DAPP_KIT_STORAGE_KEY = "sui-dapp-kit:wallet-connection-info"
+
+// One shared QueryClient for the whole app, mirroring the previous SuiProvider
+// behavior (which instantiated a QueryClient at module-load time).
+const queryClient = new QueryClient()
+
+// Slush only supports mainnet/testnet. If a Slush session is stashed in
+// localStorage from a previous mainnet/testnet visit, dapp-kit's autoConnect
+// will try to resume it on localnet and hang in `connecting`, leaving the
+// ConnectButton unclickable. Clear the stale stash before WalletProvider
+// initializes so autoConnect short-circuits, while keeping Slush in the
+// wallet picker for any manual connect attempt.
+const clearStaleSlushStashIfLocalnet = (network: string) => {
+  if (typeof window === "undefined") return
+  if (network !== ENetwork.LOCALNET) return
+  try {
+    const raw = window.localStorage.getItem(DAPP_KIT_STORAGE_KEY)
+    if (!raw) return
+    const parsed = JSON.parse(raw) as {
+      state?: { lastConnectedWalletName?: unknown }
+    }
+    if (parsed.state?.lastConnectedWalletName === SLUSH_WALLET_NAME) {
+      window.localStorage.removeItem(DAPP_KIT_STORAGE_KEY)
+    }
+  } catch {
+    // Stash unreadable / not JSON; nothing to clean up.
+  }
+}
+
 export default function ClientProviders({ children }: { children: ReactNode }) {
   const { networkConfig } = useNetworkConfig()
   const { defaultNetwork } = useHostNetworkPolicy()
 
-  // @suiware/kit always registers a Slush wallet entry, and Slush only supports
-  // mainnet/testnet. With autoConnect on localnet, dapp-kit can resume a stale
-  // Slush session from localStorage and hang in `connecting`, which leaves the
-  // ConnectButton unclickable on the setup page. Restrict autoConnect to the
-  // chains where Slush can actually return accounts.
-  const walletAutoConnect = defaultNetwork !== ENetwork.LOCALNET
+  // Run the localStorage cleanup synchronously during the first render so it
+  // executes before WalletProvider's `useRef`-bound store reads the stash. A
+  // `useEffect` would fire AFTER children mount, by which point autoConnect
+  // has already started.
+  useState(() => {
+    clearStaleSlushStashIfLocalnet(defaultNetwork)
+    return true
+  })
+
+  const slushWallet = useMemo(() => ({ name: APP_NAME }), [])
 
   return (
     <NextThemeProvider attribute="class">
       <ThemeProvider>
-        <SuiProvider
-          customNetworkConfig={networkConfig}
-          defaultNetwork={defaultNetwork}
-          walletAutoConnect={walletAutoConnect}
-          walletStashedName={APP_NAME}
-          themeSettings={themeSettings}
-        >
-          <Suspense fallback={null}>
-            <NetworkUrlSync />
-          </Suspense>
-          <WalletAccountGuard />
-          {children}
-        </SuiProvider>
+        <QueryClientProvider client={queryClient}>
+          <SuiClientProvider
+            networks={networkConfig}
+            defaultNetwork={defaultNetwork as never}
+          >
+            <WalletProvider
+              autoConnect
+              slushWallet={slushWallet}
+              theme={themeSettings}
+            >
+              <Suspense fallback={null}>
+                <NetworkUrlSync />
+              </Suspense>
+              <WalletAccountGuard />
+              {children}
+            </WalletProvider>
+          </SuiClientProvider>
+        </QueryClientProvider>
       </ThemeProvider>
     </NextThemeProvider>
   )


### PR DESCRIPTION
Price stalenes-skip configuration added considering price confidence change.

e.g. Price can lose volatility and stabilize on the same level for long, that will result in price confidence bps reduction, and will be considered in permission-less quote refresh

Resolves #126

#### PR Checklist

- [x] Tests
- [x] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable stale price tolerance parameter to AMM configuration, allowing control over quote refresh behavior based on price/confidence drift thresholds.
  * Extended CLI scripts and UI form to enable setting and updating the stale price tolerance value during AMM creation and configuration updates.

* **Tests**
  * Updated test cases to accommodate new configuration parameter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-sui-amm/pull/146)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->