### PR TITLE
fix(L-04): Orders Remain Active When Oracle Data Becomes Stale

### DIFF
--- a/packages/dapp/contracts/prop-amm/sources/config.move
+++ b/packages/dapp/contracts/prop-amm/sources/config.move
@@ -23,6 +23,9 @@ const EInvalidInventorySkewBps: vector<u8> = "inventory skew bps must be less th
 const EPriceUnderflow: vector<u8> = "price lower than minimum or underflowed";
 #[error(code = 7)]
 const EPriceOverflow: vector<u8> = "price higher than maximum or overflowed";
+#[error(code = 8)]
+const EOrderExpirationExceedsPriceAge: vector<u8> =
+    "order expiration time must not exceed the max Pyth price age";
 
 // === Constants ===
 
@@ -34,6 +37,9 @@ const HUNDRED_PERCENT_BPS: u64 = 10_000;
 /// AMM configuration for market maker executor.
 public struct AMMConfig has drop, store {
     /// Duration in milliseconds after which a placed limit order expires.
+    /// Must not exceed `max_price_age_secs * 1000` so that any stranded orders left behind by a
+    /// staleness-induced refresh abort are guaranteed to expire by the time Pyth itself would be
+    /// considered stale.
     order_expiration_time_ms: u64,
     /// Maximum acceptable age in seconds for a Pyth price feed update.
     max_price_age_secs: u64,
@@ -104,6 +110,7 @@ public fun new(
     assert!(inventory_skew_bps < HUNDRED_PERCENT_BPS, EInvalidInventorySkewBps);
     assert!(order_expiration_time_ms > 0, EInvalidOrderExpirationTime);
     assert!(max_price_age_secs > 0, EInvalidMaxPriceAge);
+    assert!(order_expiration_time_ms <= max_price_age_secs * 1000, EOrderExpirationExceedsPriceAge);
 
     AMMConfig {
         base_spread_bps,

--- a/packages/dapp/contracts/prop-amm/sources/config.move
+++ b/packages/dapp/contracts/prop-amm/sources/config.move
@@ -110,7 +110,10 @@ public fun new(
     assert!(inventory_skew_bps < HUNDRED_PERCENT_BPS, EInvalidInventorySkewBps);
     assert!(order_expiration_time_ms > 0, EInvalidOrderExpirationTime);
     assert!(max_price_age_secs > 0, EInvalidMaxPriceAge);
-    assert!(order_expiration_time_ms / 1000 <= max_price_age_secs, EOrderExpirationExceedsPriceAge);
+    assert!(
+        (order_expiration_time_ms as u128) <= (max_price_age_secs as u128) * 1000,
+        EOrderExpirationExceedsPriceAge,
+    );
 
     AMMConfig {
         base_spread_bps,

--- a/packages/dapp/contracts/prop-amm/sources/config.move
+++ b/packages/dapp/contracts/prop-amm/sources/config.move
@@ -110,7 +110,7 @@ public fun new(
     assert!(inventory_skew_bps < HUNDRED_PERCENT_BPS, EInvalidInventorySkewBps);
     assert!(order_expiration_time_ms > 0, EInvalidOrderExpirationTime);
     assert!(max_price_age_secs > 0, EInvalidMaxPriceAge);
-    assert!(order_expiration_time_ms <= max_price_age_secs * 1000, EOrderExpirationExceedsPriceAge);
+    assert!(order_expiration_time_ms / 1000 <= max_price_age_secs, EOrderExpirationExceedsPriceAge);
 
     AMMConfig {
         base_spread_bps,

--- a/packages/dapp/contracts/prop-amm/tests/config_tests.move
+++ b/packages/dapp/contracts/prop-amm/tests/config_tests.move
@@ -74,6 +74,23 @@ fun create_amm_config_rejects_zero_max_price_age() {
 }
 
 #[test]
+fun create_amm_config_accepts_order_expiration_equal_to_max_price_age() {
+    // 30_000 ms == 30 s * 1000: boundary is inclusive.
+    let amm_config = config::new(100, 10_000, 30_000, 30, 1000, 5000, 0, true);
+
+    assert_eq!(amm_config.order_expiration_time_ms(), 30_000);
+    assert_eq!(amm_config.max_price_age_secs(), 30);
+}
+
+#[test, expected_failure(abort_code = config::EOrderExpirationExceedsPriceAge)]
+fun create_amm_config_rejects_order_expiration_above_max_price_age() {
+    // 30_001 ms > 30 s * 1000: even by 1 ms must fail.
+    let _amm_config = config::new(100, 10_000, 30_001, 30, 1000, 5000, 0, true);
+
+    abort
+}
+
+#[test]
 fun create_amm_config_accepts_zero_outer_balance_bps() {
     let amm_config = config::new(100, 10_000, 30_000, 30, 1000, 0, 0, true);
 


### PR DESCRIPTION
Restrict order_expiration_time to be no more than max_price_age

Resolves #130

#### PR Checklist

- [x] Tests
- [x] Documentation
- [ ] Changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced enhanced validation for AMM configuration parameters to enforce that order expiration time aligns with and does not exceed maximum price age thresholds.

* **Tests**
  * Added comprehensive boundary tests to verify the new configuration constraint validation works correctly, including tests confirming acceptance at valid boundaries and proper rejection when limits are exceeded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenZeppelin/openzeppelin-sui-amm/pull/148)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->